### PR TITLE
Re-enable docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,9 +5,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 permissions:
   contents: write
@@ -21,15 +18,14 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.11.5'
+          cache: 'pip'
 
-      # TODO: Enable these once genlm-grammar is public.
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ".[docs]"
 
-      # - name: Install dependencies
-      #   run: |
-      #     python -m pip install --upgrade pip
-      #     pip install ".[docs]"
-
-      # - name: Deploy documentation
-      #   run: |
-      #     mkdocs gh-deploy --force
+      - name: Deploy documentation
+        run: |
+          mkdocs gh-deploy --force


### PR DESCRIPTION
This PR turns the GitHub pages docs build on (now that genlm-grammar is published)