### PR TITLE
Make JSON potential stop LLMs from emitting stupid whitespace

### DIFF
--- a/tests/potential/test_json.py
+++ b/tests/potential/test_json.py
@@ -236,3 +236,16 @@ async def test_valid_prefix_for_schema_eg1():
     )
 
     assert await potential.prefix(b"[{") == 0.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "ws",
+    [
+        b"\n\n\n",
+        b"\n    \n",
+    ],
+)
+async def test_forbids_weird_whitespace(ws):
+    potential = JsonSchema({})
+    assert await potential.prefix(ws) == -float("inf")


### PR DESCRIPTION
Sometimes an LLM will end up stuck in a JSON dead end, but it's still allowed to emit whitespace. This adds some basic checks so that only reasonably sanely formatted JSON is allowed.

In particular:

1. No lines consisting only of whitespace (empty lines are allowed)
2. No more than two newlines in a row

We could add more constraints about whitespace in a single line, but this requires us to be a bit smarter about it because the whitespace might be inside a string literal, and we shouldn't mess with that, and this seems like a decent first pass for the problems we were seeing.