### PR TITLE
Add a parameter for unbiased clipping to AWRS.

### DIFF
--- a/tests/sampler/test_awrs.py
+++ b/tests/sampler/test_awrs.py
@@ -264,3 +264,35 @@ async def test_can_clip_sample_and_remain_unbiased():
         rtol=5e-3,
         atol=5e-3,
     )
+
+
+@pytest.mark.asyncio
+async def test_remains_unbiased_even_with_high_clip():
+    potential = MockPotential(
+        list(range(100)),
+        np.log([0.01] * 101),
+    )
+    condition = MockPotential(
+        list(range(100)),
+        [-float("inf")] * 30 + [0] * 11 + [-float("inf")] * 60,
+    )
+
+    sampler_unclipped = AWRS(potential, condition, prune_logws=False)
+    sampler_clipped = AWRS(potential, condition, prune_logws=False, clip=0.9)
+
+    unclipped_weight = await monte_carlo(sampler_unclipped, [], 10000)
+    clipped_weight = await monte_carlo(sampler_clipped, [], 10000)
+
+    for _ in range(100):
+        _, log_weight, _ = await sampler_clipped.sample([])
+        if log_weight == 0:
+            break
+    else:
+        raise AssertionError("Clipped sampler never sampled full weight")
+
+    assert np.isclose(
+        np.exp(unclipped_weight.sum()),
+        np.exp(clipped_weight.sum()),
+        rtol=5e-3,
+        atol=5e-3,
+    )


### PR DESCRIPTION
If the total probability mass of accepted samples is very low, it's very likely that the particle is just going to be resampled out in SMC anyway. This means that in some cases it's actually better to return a 0 weight cheaply than it is to do an expensive scan of the entire token array.

This pull requests adds a parameter that lets you specify the amount of probability mass you're willing to discard. The method is exact, and AWRS still returns a proper weighting in this case.