### PR TITLE
Update AWRS weight calculation to use new lower-variance estimator

### DIFF
--- a/tests/sampler/test_awrs.py
+++ b/tests/sampler/test_awrs.py
@@ -297,3 +297,24 @@ async def test_awrs_with_different_limits(
             "n_monte_carlo_samples": n_monte_carlo_samples,
         },
     )
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"max_accepts": 1},
+        {"max_rejects": 1},
+        {"n_monte_carlo_samples": 0},
+    ],
+)
+def test_invalid_arguments(params):
+    potential = MockPotential(
+        [bytes([i]) for i in range(4)],
+        np.log([0.4, 0.3, 0.1, 0.1, 0.1]),
+    )
+    condition = MockPotential(
+        [bytes([i]) for i in range(4)],
+        [0, 0, float("-inf"), float("-inf"), 0],
+    )
+    with pytest.raises(ValueError):
+        AWRS(potential, condition, **params)

--- a/tests/sampler/test_awrs.py
+++ b/tests/sampler/test_awrs.py
@@ -267,3 +267,33 @@ async def test_does_not_returns_zero_weight_if_could_find_valid_token():
         tok, logw, _ = await sampler.sample([])
         assert logw != float("-inf")
         assert tok == vocab[0]
+
+
+@pytest.mark.asyncio
+@example(
+    params=([b"\x00"], [False, True], [0.5, 0.5]),
+    max_accepts=2,
+    max_rejects=2,
+    n_monte_carlo_samples=1,
+)
+@settings(deadline=None, max_examples=25)
+@given(
+    params=params(),
+    max_accepts=st.integers(min_value=2, max_value=5),
+    max_rejects=st.integers(min_value=2, max_value=5),
+    n_monte_carlo_samples=st.integers(min_value=1, max_value=5),
+)
+async def test_awrs_with_different_limits(
+    params, max_accepts, max_rejects, n_monte_carlo_samples
+):
+    await assert_monte_carlo_close(
+        sampler_cls=AWRS,
+        params=params,
+        N=10000,
+        equality_opts={"rtol": 2e-2, "atol": 2e-2},
+        sampler_opts={
+            "max_accepts": max_accepts,
+            "max_rejects": max_rejects,
+            "n_monte_carlo_samples": n_monte_carlo_samples,
+        },
+    )


### PR DESCRIPTION
This updates the AWRS algorithm to use a new estimator that works by reducing the problem to the with-replacement version.

This provides:

* Lower variance estimators across the board
* The `max_rejects` parameter, which allows you to control the runtime of the algorithm more carefully (at the cost that it will sometimes give up without finding a token and return a weight of zero)

It does come at a cost of somewhat increased runtime when the constraint is cheap to check, as the monte carlo simulations can be expensive. If this is a problem, the number of simulations to perform is configurable, and reducing it to 1 should still produce good results.