### PR TITLE
Small optimizations to PromptedLLM log prob post-processing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ authors = [
 ]
 dependencies = [
     "genlm-grammar>=0.2.0",
-    "genlm-backend>=0.1.0",
+    "genlm-backend>=0.1.1",
     "llamppl",
     "arsenal>=3.1.3",
     "IPython",


### PR DESCRIPTION
This PR speeds up the post-processing that is done on the language model logprobs when they are converted to the format expected by `LazyWeights`.