### PR TITLE
Support early rejection of anyOf in JSON potentials

### DIFF
--- a/genlm/control/potential/built_in/json.py
+++ b/genlm/control/potential/built_in/json.py
@@ -363,11 +363,6 @@ class AltParser(Parser[Union[S, T]]):
         except ParseError:
             return await self.right.parse(input)
 
-    def __floordiv__(self, other: Parser[R]) -> "Parser[Union[T, S, R]]":
-        if isinstance(other, AltParser):
-            return self.left // (self.right // other)
-        return AltParser(self, other)
-
 
 class RegexParser(Parser[str]):
     def __init__(self, pattern, group=0, options=regex.MULTILINE | regex.UNICODE):

--- a/genlm/control/potential/built_in/json.py
+++ b/genlm/control/potential/built_in/json.py
@@ -544,6 +544,13 @@ ARBITRARY_JSON = (
 
 
 def json_schema_parser(schema):
+    if "anyOf" in schema:
+        *rest, base = schema["anyOf"]
+        result = json_schema_parser(base)
+        for schema in reversed(rest):
+            result = json_schema_parser(schema) // result
+        return result
+
     if "type" not in schema:
         return ARBITRARY_JSON
     elif schema["type"] == "number":

--- a/genlm/control/potential/streaming.py
+++ b/genlm/control/potential/streaming.py
@@ -145,7 +145,13 @@ class StreamingState(ParticleState):
         self.__receive_response(token)
 
     def __receive_response(self, token):
-        response_token, response_type, *payload = self.__background.responses.get()
+        while True:
+            # In some error cases we can fail to acknowledge a response. We just silently
+            # drop these.
+            response_token, response_type, *payload = self.__background.responses.get()
+            assert response_token <= token
+            if token == response_token:
+                break
         assert token == response_token, (token, response_token, response_type)
         match response_type:
             case Responses.INCOMPLETE:

--- a/tests/potential/test_json.py
+++ b/tests/potential/test_json.py
@@ -708,3 +708,34 @@ async def test_can_reject_wrong_type_inside_any_of():
     potential = ParserPotential(parser)
 
     assert await potential.prefix(b'"') == -float("inf")
+
+
+@pytest.mark.asyncio
+async def test_can_reject_early_in_any_of():
+    schema = {
+        "anyOf": [
+            {
+                "type": "object",
+                "properties": {
+                    "a": {"type": "string"},
+                },
+                "required": ["a"],
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "a": {"type": "number"},
+                },
+                "required": ["a"],
+            },
+        ]
+    }
+
+    parser = json_schema_parser(schema)
+    potential = ParserPotential(parser)
+
+    assert await potential.prefix(b'"') == -float("inf")
+    assert await potential.prefix(b'{"a":') == 0
+    assert await potential.prefix(b'{"a": "') == 0
+    assert await potential.prefix(b'{"a": 1') == 0
+    assert await potential.prefix(b'{"a": {') == -float("inf")

--- a/tests/potential/test_json.py
+++ b/tests/potential/test_json.py
@@ -580,7 +580,7 @@ async def test_validates_a_list_of_integers_parser_only():
 async def test_can_calculate_many_prefixes():
     potential = JsonSchema({"type": "object"})
 
-    for i in range(10000):
+    for i in range(100):
         prefix = b'{ "' + str(i).encode("utf-8")
         pot = await potential.prefix(prefix)
         assert pot == 0.0
@@ -688,3 +688,23 @@ async def test_cache_eviction_with_many_prefixes(problem, cache_size):
     assert all(result == 0.0 for result in results)
 
     assert await potential.complete(problem.document) == 0.0
+
+
+@pytest.mark.asyncio
+async def test_can_reject_wrong_type_inside_any_of():
+    schema = {
+        "anyOf": [
+            {
+                "anyOf": [
+                    {
+                        "type": "object",
+                    },
+                ]
+            },
+        ]
+    }
+
+    parser = json_schema_parser(schema)
+    potential = ParserPotential(parser)
+
+    assert await potential.prefix(b'"') == -float("inf")


### PR DESCRIPTION
Our JSON potential has essentially two parts to it:

1. A full validator that rejects anything not conforming to the schema, but has to wait for whole parts to be read (e.g. can't reject a string until it's closed, can't reject an object until it's been fully completed), so will often result in cases where the prefix is allowed but the particle is dead.
2. A parser combinator based "coarse" potential that cannot validate the whole schema but can often reject prefixes as soon as they become invalid.

Previously we were relying on only (1) for anyOf support, which meant that in some cases (e.g. when we had an anyOf of several objects) the LLM was not prevented from starting an invalid value there and just continuing it on indefinitely. This fixes that by adding parser support for anyOf.

While in the area I also fixed two other problems:

1. Error states could sometimes trigger an assertion inside `__receive_response` in `StreamingPotential` because receiving a message got interrupted. This now silently drops any earlier messages received.
2. `AltParser` was often very slow due to the way it nested its branches. It now reorders branches in a way that should be more efficient, especially when early branches are accepted.