### PR TITLE
Grab-bag of fixes to JSON

### DIFF
--- a/genlm/control/potential/built_in/json.py
+++ b/genlm/control/potential/built_in/json.py
@@ -374,7 +374,7 @@ class FilterParser(Parser[T]):
         return result
 
     def __repr__(self):
-        return f"{self.base}.map({self.apply})"
+        return f"{self.base}.filter({self.predicate})"
 
 
 R = TypeVar("R")

--- a/genlm/control/potential/built_in/json.py
+++ b/genlm/control/potential/built_in/json.py
@@ -65,9 +65,6 @@ def is_utf8_start_byte(n: int) -> bool:
     return False
 
 
-BAD_WHITESPACE = regex.compile(rb"(?:\n\s*\n)", regex.MULTILINE)
-
-
 def chunk_to_complete_utf8(byte_blocks):
     for s in chunk_bytes_to_strings(byte_blocks):
         yield s.encode("utf-8")
@@ -130,7 +127,10 @@ class StreamingJsonSchema(StreamingPotential):
         return 0.0
 
 
-VALID_JSON_START = regex.compile(rb'^\[|\{|"|(-?[0-9])|[nft]', regex.MULTILINE)
+BAD_WHITESPACE = regex.compile(rb"(?:\n\s*\n)", regex.MULTILINE)
+VALID_JSON_START = regex.compile(
+    rb'^[ \n]{0,2}\[|\{|"|(-?[0-9])|[nft]', regex.MULTILINE
+)
 
 
 class ValidateJSON(Potential):
@@ -155,7 +155,10 @@ class ValidateJSON(Potential):
         # Sometimes a model can get itself into a position where it can't
         # generate any valid tokens, but it can keep generating whitespace
         # indefinitely.
-        if BAD_WHITESPACE.search(context):
+        #
+        # pos=1 because we specifically allow two newlines at the start,
+        # as LLMs like doing that for tokenization reasons.
+        if BAD_WHITESPACE.search(context, pos=1):
             return float("-inf")
         for c in context:
             # Forbid control characters other than newline.

--- a/genlm/control/potential/streaming.py
+++ b/genlm/control/potential/streaming.py
@@ -61,7 +61,8 @@ class RunningInThread:
             self.last_message, chunk = self.incoming_data.get()
             if chunk is SHUTDOWN_TOKEN:
                 break
-            yield chunk
+            if chunk:
+                yield chunk
             self.responses.put((self.last_message, Responses.INCOMPLETE))
 
     def run(self):
@@ -121,8 +122,7 @@ class StreamingState(ParticleState):
         if incremental_context and incremental_context[-1] == self.owner.eos:
             finish = True
             incremental_context = incremental_context[:-1]
-        bytes(incremental_context)
-        await self.__send_message(incremental_context)
+        await self.__send_message(bytes(incremental_context))
         if finish:
             await self.finish()
 
@@ -130,18 +130,21 @@ class StreamingState(ParticleState):
         await self.__initialize_background()
         self.shutdown()
 
+    async def start(self):
+        await self.__initialize_background()
+        await self.__send_message(b"")
+
     @property
     def current_score(self):
         return self.__score
 
     async def __send_message(self, message):
         if self.__background.complete:
-            self.__score = -float("inf")
-            self.diagnostics["error"] = self.__background.error
-            import traceback
-
-            traceback.print_exception(self.__background.error)
+            if self.__background.error and "error" not in self.diagnostics:
+                self.__score = -float("inf")
+                self.diagnostics["error"] = self.__background.error
             return
+
         token = self.__new_token()
         self.__background.incoming_data.put((token, message))
 

--- a/tests/potential/test_json.py
+++ b/tests/potential/test_json.py
@@ -13,6 +13,7 @@ from genlm.control.potential.built_in.json import (
     StringSource,
     Input,
     FloatParser,
+    WHITESPACE_PARSER,
 )
 from genlm.control.potential.streaming import AsyncSource
 import json
@@ -748,7 +749,7 @@ def test_chunk_to_complete_utf8_will_error_on_invalid_unicode():
 @pytest.mark.asyncio
 async def test_rejects_using_unicode_whitespace():
     pot = JsonSchema({"type": "object"})
-    assert await pot.prefix(" \u3000".encode("utf-8")) == -float("inf")
+    assert await pot.prefix("{ \u3000".encode("utf-8")) == -float("inf")
 
 
 def test_chunking_immediately_rejects_invalid_utf8_bytes():
@@ -779,3 +780,7 @@ async def test_no_double_newline_after_start():
     potential = JsonSchema({"type": "object"})
     assert await potential.prefix(b"{\n\n") == -float("inf")
     assert await potential.prefix(b"{\n  \n") == -float("inf")
+
+
+def test_repr_of_filter():
+    assert "filter" in repr(WHITESPACE_PARSER)

--- a/tests/potential/test_json.py
+++ b/tests/potential/test_json.py
@@ -40,14 +40,6 @@ async def test_rejects_as_prefix_when_no_valid_continuation():
 
 
 @pytest.mark.asyncio
-async def test_whitespace_is_valid_prefix_and_invalid_complete():
-    potential = JsonSchema({"type": "object"})
-
-    assert await potential.prefix(b" ") == 0.0
-    assert await potential.complete(b" ") == -float("inf")
-
-
-@pytest.mark.asyncio
 @pytest.mark.parametrize("schema", [{"type": "array", "items": {"type": "integer"}}])
 @pytest.mark.parametrize(
     "context",
@@ -751,3 +743,39 @@ async def test_will_reject_invalid_unicode_at_end():
 def test_chunk_to_complete_utf8_will_error_on_invalid_unicode():
     with pytest.raises(UnicodeDecodeError):
         list(chunk_to_complete_utf8([b"{ }\n\n    \xe2\x9d\x8d\xb0"]))
+
+
+@pytest.mark.asyncio
+async def test_rejects_using_unicode_whitespace():
+    pot = JsonSchema({"type": "object"})
+    assert await pot.prefix(" \u3000".encode("utf-8")) == -float("inf")
+
+
+def test_chunking_immediately_rejects_invalid_utf8_bytes():
+    def bad_bytes():
+        yield b"\xc0"
+        assert False
+
+    with pytest.raises(UnicodeDecodeError):
+        list(chunk_to_complete_utf8(bad_bytes()))
+
+
+def test_chunking_bails_early_on_invalid_start_bytes():
+    def bad_bytes():
+        yield b"\xe3\x86\x8c\x80"
+        assert False
+
+    with pytest.raises(UnicodeDecodeError):
+        list(chunk_to_complete_utf8(bad_bytes()))
+
+
+@pytest.mark.asyncio
+async def test_whitespace_at_start_is_rejected():
+    assert await ValidateJSON().prefix(b" ") == -float("inf")
+
+
+@pytest.mark.asyncio
+async def test_no_double_newline_after_start():
+    potential = JsonSchema({"type": "object"})
+    assert await potential.prefix(b"{\n\n") == -float("inf")
+    assert await potential.prefix(b"{\n  \n") == -float("inf")

--- a/tests/potential/test_json.py
+++ b/tests/potential/test_json.py
@@ -771,8 +771,11 @@ def test_chunking_bails_early_on_invalid_start_bytes():
 
 
 @pytest.mark.asyncio
-async def test_whitespace_at_start_is_rejected():
-    assert await ValidateJSON().prefix(b" ") == -float("inf")
+async def test_long_whitespace_at_start_is_rejected():
+    assert await ValidateJSON().prefix(b"  ") == 0
+    assert await ValidateJSON().prefix(b"\n\n") == 0
+    assert await ValidateJSON().prefix(b"    ") == -float("inf")
+    assert await ValidateJSON().prefix(b"\n\n  ") == -float("inf")
 
 
 @pytest.mark.asyncio

--- a/tests/potential/test_stateful.py
+++ b/tests/potential/test_stateful.py
@@ -194,3 +194,13 @@ def test_priority_map_repr():
     x[0] = 0
     x[1] = 1
     assert repr(x) == "PriorityMap({0: 0, 1: 1})"
+
+
+@pytest.mark.asyncio
+async def test_error_on_startup_is_correctly_handled():
+    class ErrorPotential(StreamingPotential):
+        def calculate_score_from_stream(self, stream) -> float:
+            raise Exception("Oh no")
+
+    potential = ErrorPotential(vocabulary=list(range(256)))
+    assert await potential.prefix(b"") == -float("inf")

--- a/tests/potential/test_stateful.py
+++ b/tests/potential/test_stateful.py
@@ -74,16 +74,17 @@ async def test_will_time_out_if_too_many_threads_start(monkeypatch):
 @pytest.mark.asyncio
 async def test_finished_clone_is_no_op():
     potential = DummyPotential()
-    state = potential.new_state()
+    state = await potential.new_state()
     await state.finish()
     assert state.finished
     assert (await state.clone()) is state
 
 
-def test_must_specify_state_class_or_implement_new_state():
+@pytest.mark.asyncio
+async def test_must_specify_state_class_or_implement_new_state():
     potential = StatefulPotential(vocabulary=[0, 1])
     with pytest.raises(NotImplementedError):
-        potential.new_state()
+        await potential.new_state()
 
 
 def test_tokens_have_right_repr():
@@ -118,7 +119,7 @@ async def test_cleanup_clears_up_async_tasks():
 @pytest.mark.asyncio
 async def test_operations_after_finish_are_ignored():
     potential = DummyAsyncPotential()
-    state = potential.new_state()
+    state = await potential.new_state()
     await state.update_context([0])
     await state.finish()
     assert state.finished


### PR DESCRIPTION
This pull request is a bit of a miscellany (sorry) which arises from trying to fix every error and model weirdness we're running into with something we've built on top of genlm-control. Sorry for the slight incoherence of it that results.

This includes:

1. Much better handling of invalid UTF-8 - rejecting it in places we were previously failing to reject it, and rejecting it much earlier.
2. Much tighter guardrails on models ability to do silly nonsense with whitespace to get around the fact that it doesn't know what to do. In particular, non-ASCII whitespace is banned (outside of strings), and JSON is not allowed to start with whitespace. Blank lines are also now forbidden.