### PR TITLE
Fail-fast for const in JSON schema

### DIFF
--- a/genlm/control/potential/built_in/json.py
+++ b/genlm/control/potential/built_in/json.py
@@ -402,12 +402,10 @@ class ConstParser(Parser[None]):
 
     async def parse(self, input: Input) -> None:
         await input.skip_whitespace()
-        i = 0
-        while c := await input.read(1):
-            if c != self.value[i]:
-                raise ParseError(f"Expected char {self.value[i]} but got {c}")
-            i += 1
-        assert i == len(self.value)
+        for expected in self.value:
+            got = await input.read(1)
+            if got != expected:
+                raise ParseError(f"Expected char {expected} but got {got}")
 
 
 class RegexParser(Parser[str]):

--- a/tests/potential/test_json.py
+++ b/tests/potential/test_json.py
@@ -804,3 +804,14 @@ async def test_const_fails_fast_in_string_literals():
     assert await potential.prefix(b" ") == 0
     assert await potential.prefix(b'"Hello') == 0
     assert await potential.prefix(b'"Hi') == -float("inf")
+
+
+@pytest.mark.asyncio
+async def test_const_in_object():
+    potential = ParserPotential(
+        json_schema_parser({"type": "object", "properties": {"foo": {"const": None}}})
+    )
+
+    assert await potential.prefix(b'{"foo": nu') == 0
+    assert await potential.complete(b'{"foo": null}') == 0
+    assert await potential.prefix(b'{"foo": f') == -float("inf")

--- a/tests/potential/test_json.py
+++ b/tests/potential/test_json.py
@@ -787,3 +787,20 @@ async def test_no_double_newline_after_start():
 
 def test_repr_of_filter():
     assert "filter" in repr(WHITESPACE_PARSER)
+
+
+@pytest.mark.asyncio
+async def test_const_fails_fast():
+    potential = ParserPotential(json_schema_parser({"const": False}))
+    assert await potential.prefix(b" ") == 0
+    assert await potential.prefix(b" f") == 0
+    assert await potential.prefix(b" false") == 0
+    assert await potential.prefix(b" n") == -float("inf")
+
+
+@pytest.mark.asyncio
+async def test_const_fails_fast_in_string_literals():
+    potential = ParserPotential(json_schema_parser({"const": "Hello world"}))
+    assert await potential.prefix(b" ") == 0
+    assert await potential.prefix(b'"Hello') == 0
+    assert await potential.prefix(b'"Hi') == -float("inf")


### PR DESCRIPTION
This adds support for `const` to our JSON schema validation that allows it to fail at the first token that is clearly wrong rather than having to parse the whole thing.

This is a bit overly strict, in that there are some cases where there are multiple valid string representations of the same values (e.g. a const object, or different floating point representations). In this case the parser only accepts a single canonical version of them. This doesn't impact typical usage, and even in the cases it does affect it seems unproblematic.