### PR TITLE
Validate JSON Schemas before using them

### DIFF
--- a/genlm/control/potential/built_in/json.py
+++ b/genlm/control/potential/built_in/json.py
@@ -171,6 +171,7 @@ class ValidateJSON(Potential):
 
 
 def JsonSchema(schema):
+    Draft7Validator.check_schema(schema)
     return (
         ValidateJSON()
         * StreamingJsonSchema(schema)

--- a/tests/potential/test_json.py
+++ b/tests/potential/test_json.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass
 from hypothesis import given, strategies as st, assume, example, settings, reject
 from hypothesis_jsonschema import from_schema
 import asyncio
+from jsonschema import SchemaError
 
 
 @pytest.mark.asyncio
@@ -815,3 +816,8 @@ async def test_const_in_object():
     assert await potential.prefix(b'{"foo": nu') == 0
     assert await potential.complete(b'{"foo": null}') == 0
     assert await potential.prefix(b'{"foo": f') == -float("inf")
+
+
+def test_errors_on_bad_types():
+    with pytest.raises(SchemaError):
+        JsonSchema({"type": "float"})


### PR DESCRIPTION
Apparently *using* a schema in a schema validator doesn't actually check the schema for validity. We're running into a bunch of invalid schema in the wild which then produce very confusing results, so this PR adds a check for schema validity when you create a JsonSchema potential.