### PR TITLE
Prettier printing of bytes objects.

### DIFF
--- a/genlm/control/sampler/sequence.py
+++ b/genlm/control/sampler/sequence.py
@@ -11,6 +11,7 @@ from llamppl import smc_standard
 from genlm.control.potential import Potential
 from genlm.control.constant import EOS, EndOfSequence
 from genlm.control.sampler.token import TokenSampler
+from genlm.control.util import escape
 
 
 class SMC:
@@ -323,12 +324,12 @@ class SequenceModel(Model):
         return (
             f"{self.weight:.2f}:\t"
             + colors.magenta % "["
-            + (colors.magenta % "|").join(repr(y) for y in self.token_ctx)
+            + (colors.magenta % "|").join(escape(y) for y in self.token_ctx)
             + colors.magenta % "]"
         )
 
     def string_for_serialization(self):
-        return "|".join(repr(y) for y in self.token_ctx)
+        return "|".join(escape(y) for y in self.token_ctx)
 
     def immutable_properties(self):
         return set(["unit_sampler", "critic"])

--- a/genlm/control/util.py
+++ b/genlm/control/util.py
@@ -275,3 +275,13 @@ def fast_sample_lazyweights(lazyweights):
     assert lazyweights.is_log
     token_id = fast_sample_logprobs(lazyweights.weights, size=1)[0]
     return lazyweights.decode[token_id]
+
+
+def escape(x):
+    if isinstance(x, int):  # assume its a byte
+        x = bytes([x])
+    if isinstance(x, bytes):
+        y = repr(x)[2:-1]
+    else:
+        y = repr(x)[1:-1]
+    return y.replace(" ", "␣")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from genlm.control.util import LazyWeights, load_trie
+from genlm.control.util import LazyWeights, load_trie, escape
 
 
 def test_lazy_weights_basic():
@@ -187,3 +187,9 @@ def test_lazy_weights_repr():
 
     lw = LazyWeights(weights, encode, decode, log=False)
     lw.__repr__()
+
+
+def test_escape():
+    assert escape(10) == "\\n"
+    assert escape(b"hello") == "hello"
+    assert escape("hello") == "hello"


### PR DESCRIPTION
`[b" a"|b" great"]` is now visualized as `[␣a|␣great]` during SMC when `verbosity>1`.