### PR TITLE
Properly escape EOS.

### DIFF
--- a/genlm/control/util.py
+++ b/genlm/control/util.py
@@ -2,6 +2,8 @@ import numpy as np
 from genlm.grammar import Float, Log
 from arsenal.maths import logsumexp
 
+from genlm.control.constant import EndOfSequence
+
 
 class LazyWeights:
     """
@@ -278,7 +280,9 @@ def fast_sample_lazyweights(lazyweights):
 
 
 def escape(x):
-    if isinstance(x, int):  # assume its a byte
+    if isinstance(x, EndOfSequence):
+        return repr(x)
+    elif isinstance(x, int):  # assume its a byte
         x = bytes([x])
     if isinstance(x, bytes):
         y = repr(x)[2:-1]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+from genlm.control.constant import EOS
 from genlm.control.util import LazyWeights, load_trie, escape
 
 
@@ -193,3 +194,4 @@ def test_escape():
     assert escape(10) == "\\n"
     assert escape(b"hello") == "hello"
     assert escape("hello") == "hello"
+    assert escape(EOS) == "EOS"


### PR DESCRIPTION
Properly escape `EndOfSequence` tokens during the visualization of an SMC run.