### PR TITLE
Fix: Coerce to bytes

### DIFF
--- a/genlm/control/potential/built_in/llm.py
+++ b/genlm/control/potential/built_in/llm.py
@@ -119,6 +119,9 @@ class TokenMappings(NamedTuple):
             eos_byte_strings (list[bytes]): List of byte strings representing EOS tokens.
         """
         eos_byte_strings = _compat_eos_tokens(eos_byte_strings, kwargs)
+        # Coerce to bytes -> make spawn_new_eos accept tokens, bytes, or any
+        # mix without the caller having to remember.
+        eos_byte_strings = [bytes(bs) for bs in eos_byte_strings]
         if len(set(eos_byte_strings)) != len(eos_byte_strings):
             raise ValueError("Duplicate eos byte strings")
 

--- a/genlm/control/sampler/sequence.py
+++ b/genlm/control/sampler/sequence.py
@@ -109,10 +109,6 @@ class SMC:
             twist_with_critic=ess_threshold > 0,
         )
 
-        # Default to stratified resampling: lower variance than multinomial.
-        # Caller can override via `resampling_method` in **kwargs.
-        kwargs.setdefault("resampling_method", "stratified")
-
         particles = await smc_standard(
             model=model,
             n_particles=n_particles,

--- a/genlm/control/sampler/sequence.py
+++ b/genlm/control/sampler/sequence.py
@@ -109,6 +109,10 @@ class SMC:
             twist_with_critic=ess_threshold > 0,
         )
 
+        # Default to stratified resampling: lower variance than multinomial.
+        # Caller can override via `resampling_method` in **kwargs.
+        kwargs.setdefault("resampling_method", "stratified")
+
         particles = await smc_standard(
             model=model,
             n_particles=n_particles,

--- a/tests/potential/test_llm.py
+++ b/tests/potential/test_llm.py
@@ -195,6 +195,22 @@ def test_invalid_eos_tokens(llm):
         llm.eos_byte_strings = [llm.token_maps.decode[0].byte_string]
 
 
+def test_eos_accepts_token_object(llm):
+    """A `Token` as EOS is coerced to bytes and recognised (used to raise
+    "EOS token not in language model vocabulary")."""
+    tok = llm.vocab[5]
+    new_llm = llm.spawn_new_eos(eos_byte_strings=[tok])
+    assert type(new_llm.eos_byte_strings[0]) is bytes
+    assert tok.token_id in new_llm.token_maps.eos_idxs
+
+
+def test_eos_token_and_equal_bytes_are_duplicates(llm):
+    """A `Token` and its equal plain bytes are the same EOS by content."""
+    tok = llm.vocab[5]
+    with pytest.raises(ValueError, match="Duplicate eos byte strings"):
+        llm.spawn_new_eos(eos_byte_strings=[tok, bytes(tok)])
+
+
 def test_invalid_token_encoding(llm):
     # Test encoding invalid tokens
     invalid_tokens = [b"INVALID_TOKEN"]


### PR DESCRIPTION
Normalize EOS entries that arrive as Token objects (which subclass bytes but compare/hash by token_id) to plain bytes, so EOS is matched by byte content.
Fixes a bug in #135 where passing a Token as EOS raised "EOS token not in language model vocabulary."