### PR TITLE
inf-safe normalization

### DIFF
--- a/genlm/control/potential/built_in/wfsa.py
+++ b/genlm/control/potential/built_in/wfsa.py
@@ -1,6 +1,5 @@
 import string
 import numpy as np
-from arsenal.maths import logsumexp
 
 from genlm.grammar import Float, Log, WFSA as BaseWFSA
 from genlm.grammar.lark_interface import interegular_to_wfsa
@@ -133,10 +132,19 @@ class WFSA(Potential):
             return float("-inf"), curr
 
         bkwd = self.wfsa.epsremove.backward
-        log_ctx_w = logsumexp([(curr[i] * bkwd[i]).score for i in curr])
+        # Inlined logsumexp with infinity short-circuits.
+        arr = np.asarray(
+            [(curr[i] * bkwd[i]).score for i in curr], dtype=np.float64
+        )
+        vmax = arr.max()
+        if vmax == np.inf:
+            return float("inf"), curr
+        if vmax == -np.inf:
+            return float("-inf"), curr
+        log_ctx_w = vmax + np.log(np.exp(arr - vmax).sum())
 
         if np.isnan(log_ctx_w):
-            return float("-inf"), curr
+            raise FloatingPointError("NaN in WFSA prefix weights")
 
         return log_ctx_w, curr
 
@@ -172,6 +180,9 @@ class WFSA(Potential):
 
         if log_ctx_w == float("-inf"):
             raise ValueError(f"Context {context!r} has zero weight.")
+        # Conditional log-weights are undefined when context weight diverges
+        if log_ctx_w == float("inf"):
+            raise ValueError(f"Context {context!r} has divergent weight.")
 
         bkwd = self.wfsa.epsremove.backward
 

--- a/tests/potential/test_wfsa.py
+++ b/tests/potential/test_wfsa.py
@@ -302,3 +302,16 @@ async def test_wfsa_divergent_backward_short_circuit():
         assert await pot.prefix(b"a") == float("inf")
         with pytest.raises(ValueError, match="Context.*divergent weight"):
             await pot.logw_next(b"a")
+
+
+@pytest.mark.asyncio
+async def test_wfsa_prefix_raises_on_nan():
+    """A NaN reaching _prefix indicates an upstream bug; verify it raises
+    loudly instead of being silently coerced to -inf."""
+    m = BaseWFSA(Log)
+    m.add_I(0, Log.one)
+    m.add_arc(0, b"a"[0], 1, Log(float("nan")))
+    m.add_F(1, Log.one)
+    pot = WFSA(m)
+    with pytest.raises(FloatingPointError, match="NaN in WFSA prefix weights"):
+        await pot.prefix(b"a")

--- a/tests/potential/test_wfsa.py
+++ b/tests/potential/test_wfsa.py
@@ -1,4 +1,6 @@
 import re
+import warnings
+
 import pytest
 import graphviz
 import numpy as np
@@ -272,3 +274,33 @@ async def test_zero_weight_context():
     pot = BoolFSA.from_regex(r"a")
     with pytest.raises(ValueError, match="Context.*has zero weight."):
         await pot.logw_next(b"b")
+
+
+@pytest.mark.asyncio
+async def test_wfsa_dead_end_prefix(float_wfsa):
+    """Consuming 'ad' lands the FSA in dead-end state 3 (backward = -inf).
+    Exercises the vmax==-inf short-circuit in _prefix; the previous arsenal
+    logsumexp produced NaN here via -inf - -inf and emitted a RuntimeWarning."""
+    pot = WFSA(float_wfsa)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", category=RuntimeWarning)
+        assert await pot.prefix(b"ad") == -float("inf")
+
+
+@pytest.mark.asyncio
+async def test_bool_fsa_divergent_scc():
+    """Regression: ``[\\s\\S]*PATTERN[\\s\\S]*`` over a large default charset
+    produces an FSA with diverging closure (Log.star score>=0).
+    This returned NaN and BoolFSA.prefix returned-inf for every non-matching prefix.
+    logw_next on a divergent context has no well-defined conditional, so it must raise."""
+    pat = r"[\s\S]*[eE]njoy\s+[A-Za-z]+[iI][nN][gG][\s\S]*"
+    fsa = BoolFSA.from_regex(pat)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", category=RuntimeWarning)
+        assert await fsa.prefix(b"") == 0
+        assert await fsa.prefix(b"Hello") == 0
+        assert await fsa.complete(b"I enjoy walking.") == 0
+        assert await fsa.complete(b"I enjoy films.") == -float("inf")
+        with pytest.raises(ValueError, match="Context.*divergent weight"):
+            await fsa.logw_next(b"")

--- a/tests/potential/test_wfsa.py
+++ b/tests/potential/test_wfsa.py
@@ -288,19 +288,17 @@ async def test_wfsa_dead_end_prefix(float_wfsa):
 
 
 @pytest.mark.asyncio
-async def test_bool_fsa_divergent_scc():
-    """Regression: ``[\\s\\S]*PATTERN[\\s\\S]*`` over a large default charset
-    produces an FSA with diverging closure (Log.star score>=0).
-    This returned NaN and BoolFSA.prefix returned-inf for every non-matching prefix.
-    logw_next on a divergent context has no well-defined conditional, so it must raise."""
-    pat = r"[\s\S]*[eE]njoy\s+[A-Za-z]+[iI][nN][gG][\s\S]*"
-    fsa = BoolFSA.from_regex(pat)
-
+async def test_wfsa_divergent_backward_short_circuit():
+    """Construct a WFSA with a +inf-weighted arc (the kind of value
+    genlm-grammar produces from a divergent SCC closure. Use the +inf
+    short-circuit in _prefix and the divergent-weight raise in logw_next."""
+    m = BaseWFSA(Log)
+    m.add_I(0, Log.one)
+    m.add_arc(0, b"a"[0], 1, Log(float("inf")))
+    m.add_F(1, Log.one)
+    pot = WFSA(m)
     with warnings.catch_warnings():
         warnings.simplefilter("error", category=RuntimeWarning)
-        assert await fsa.prefix(b"") == 0
-        assert await fsa.prefix(b"Hello") == 0
-        assert await fsa.complete(b"I enjoy walking.") == 0
-        assert await fsa.complete(b"I enjoy films.") == -float("inf")
+        assert await pot.prefix(b"a") == float("inf")
         with pytest.raises(ValueError, match="Context.*divergent weight"):
-            await fsa.logw_next(b"")
+            await pot.logw_next(b"a")

--- a/tests/sampler/test_unit_sampler.py
+++ b/tests/sampler/test_unit_sampler.py
@@ -19,6 +19,7 @@ from conftest import MockPotential
 @pytest.mark.asyncio
 async def test_multi_token_unit_sampler_basic():
     """Test basic multi-token unit sampling with boundary tokens."""
+    np.random.seed(0) # Seed deterministic sampling
     # Create a simple mock potential
     vocab = [b"hello", b" ", b"world", b"!"]
     logws = np.log([0.4, 0.1, 0.3, 0.1, 0.1])


### PR DESCRIPTION
  - WFSA._prefix: inline the vmax-subtract logsumexp and short-circuit vmax == +inf (return +inf) and vmax == −inf (return −inf); raise FloatingPointError on NaN instead of masking
  - WFSA.logw_next: raise ValueError when the prefix weight is +inf