### PR TITLE
Sampling from arbitrary proposals #139

### DIFF
--- a/docs/samplers.md
+++ b/docs/samplers.md
@@ -18,6 +18,48 @@ token, logw, logp = await sampler.sample(context)
 
 `DirectTokenSampler` is efficient when the potential's `logw_next` method is efficient (e.g., for language models). However, for potentials with large vocabularies or expensive `logw_next` computations, other sampling strategies may be more appropriate.
 
+## Sampling from arbitrary proposals
+
+Both [`DirectTokenSampler`][genlm.control.sampler.token.DirectTokenSampler] and [`AWRS`][genlm.control.sampler.token.AWRS] accept an optional `proposal` potential. When supplied, the sampler draws candidate tokens from `proposal.logw_next` and applies a per-step importance correction so the returned `(token, weight)` remains properly weighted with respect to the *target*'s `logw_next`. With `proposal=None` (the default), each sampler is its own proposal.
+
+A typical use case is pairing a larger target LM with a smaller proposal LM that shares the same tokenizer. Below we use Llama-3.2-3B as the target and Llama-3.2-1B as the proposal for molecular synthesis. The task (taken from [`genlm-eval`](https://github.com/genlm/genlm-eval)) is to generate a valid SMILES string conditioned on a few example molecules:
+
+```python
+from genlm.control import PromptedLLM, direct_token_sampler
+from genlm.eval.domains.molecular_synthesis import (
+    PartialSMILES, default_prompt_formatter, MolecularSynthesisInstance,
+)
+
+# Llama-3.2-1B and -3B share the same tokenizer, so their vocab_eos matches.
+target = PromptedLLM.from_name("meta-llama/Llama-3.2-3B")
+proposal = PromptedLLM.from_name("meta-llama/Llama-3.2-1B")
+
+instance = MolecularSynthesisInstance(
+    instance_id=0,
+    molecules=["BrC1=C2C3C4C3N(CC4C#C)C2=NC(=O)S1"],
+)
+prompt_ids = default_prompt_formatter(target.model.tokenizer, instance)
+target.prompt_ids = prompt_ids
+proposal.prompt_ids = prompt_ids
+
+# Byte-level SMILES validity, coerced onto the LM's token vocabulary.
+smiles_critic = PartialSMILES().coerce(target, f=b"".join)
+
+sampler = direct_token_sampler(target, proposal=proposal)
+sequences = await sampler.smc(
+    n_particles=10, ess_threshold=0.5, max_tokens=40, critic=smiles_critic,
+)
+```
+
+The same `proposal=` argument is available on `AWRS` when the constraint is boolean:
+
+```python
+sampler = AWRS(target, smiles_critic, proposal=proposal)
+```
+
+Other use cases include the same LM at a different temperature (e.g., a flatter proposal that explores more broadly), or the same LM under a different prompt (e.g., a more permissive instruction as the proposal).
+
+Requirements: The proposal must share the target's `vocab_eos` (same tokenizer). Cross-tokenizer proposals raise `ValueError`.
 
 ## Adaptive Weighted Rejection Sampling
 

--- a/genlm/control/sampler/__init__.py
+++ b/genlm/control/sampler/__init__.py
@@ -12,19 +12,23 @@ from .unit import (
 from genlm.control.potential import Potential
 
 
-def direct_token_sampler(potential):
+def direct_token_sampler(potential, proposal=None):
     """Create a `DirectTokenSampler` that samples directly from a potential's vocabulary.
 
-    See `DirectTokenSampler` for more details.
+    See `DirectTokenSampler` for more details, including the `proposal` argument.
 
     Args:
         potential (Potential): The potential function to sample from. Should have an efficient logw_next method.
+        proposal (Potential, optional): Optional importance-sampling proposal;
+            must share `potential.vocab_eos`. Defaults to None.
 
     Returns:
-        (DirectTokenSampler): A sampler that directly samples tokens from the potential's vocabulary.
+        (DirectTokenSampler): A sampler that samples tokens from `potential`
+            (or `proposal`, if supplied) and returns importance weights relative
+            to `potential`.
     """
     assert isinstance(potential, Potential)
-    return DirectTokenSampler(potential)
+    return DirectTokenSampler(potential, proposal=proposal)
 
 
 def eager_token_sampler(iter_potential, item_potential):

--- a/genlm/control/sampler/token.py
+++ b/genlm/control/sampler/token.py
@@ -1,3 +1,4 @@
+import asyncio
 import numpy as np
 from arsenal import colors
 from llamppl import SubModel
@@ -139,13 +140,15 @@ class DirectTokenSampler(TokenSampler):
                 token = draw(logps.exp().materialize())
             return token, logws.sum(), logps[token]
 
-        proposal_logws = await self.proposal.logw_next(context)
+        proposal_logws, target_logws = await asyncio.gather(
+            self.proposal.logw_next(context),
+            self.potential.logw_next(context),
+        )
         proposal_logps = proposal_logws.normalize()
         if draw is None:
             token = fast_sample_lazyweights(proposal_logps)
         else:
             token = draw(proposal_logps.exp().materialize())
-        target_logws = await self.potential.logw_next(context)
         logw = (
             target_logws[token]
             - proposal_logws[token]
@@ -332,8 +335,10 @@ class AWRS(TokenSampler):
             logws = await self.potential.logw_next(context)
             target_logws = None
         else:
-            target_logws = await self.potential.logw_next(context)
-            logws = await self.proposal.logw_next(context)
+            target_logws, logws = await asyncio.gather(
+                self.potential.logw_next(context),
+                self.proposal.logw_next(context),
+            )
 
         if self.prune_logws:
             logws = self._prune_logws(logws)

--- a/genlm/control/sampler/token.py
+++ b/genlm/control/sampler/token.py
@@ -6,6 +6,7 @@ import warnings
 
 from genlm.control.util import fast_sample_lazyweights
 from genlm.control.sampler.set import SetSampler
+from genlm.control.sampler.util import _validate_proposal_vocab
 
 
 class TokenSampler(SubModel):
@@ -87,7 +88,13 @@ class DirectTokenSampler(TokenSampler):
     of a potential.
 
     Args:
-        potential (Potential): The potential function to sample from
+        potential (Potential): The potential function to sample from.
+        proposal (Potential, optional): If supplied, tokens are drawn from
+            `proposal.logw_next` and reweighted by `target/proposal` so the result
+            stays properly weighted with respect to `potential.logw_next`. Must
+            share `potential.vocab_eos` (cross-tokenizer not yet supported). When
+            `None` (the default), the target acts as its own proposal. The proposal
+            must place positive mass on every token the target weights positively.
 
     Warning:
         Only use this sampler if the potential's `logw_next` method is efficient. This is the case
@@ -96,9 +103,12 @@ class DirectTokenSampler(TokenSampler):
         sampler will be slow.
     """
 
-    def __init__(self, potential):
+    def __init__(self, potential, proposal=None):
         super().__init__(target=potential)
         self.potential = potential
+        if proposal is not None:
+            _validate_proposal_vocab(potential, proposal)
+        self.proposal = proposal
 
     async def sample(self, context, draw=None):
         """Sample a token and weight that are properly weighted with respect to the target potential's `logw_next` method.
@@ -111,19 +121,37 @@ class DirectTokenSampler(TokenSampler):
         \\textsf{target.logw_next}(x_n | x_1, \\ldots, x_{n-1})
         $$
 
-        The returned weight corresponds to the log normalizing constant of $\\textsf{target.logw_next}(x_n | x_1, \\ldots, x_{n-1})$.
+        Without a proposal, the returned weight is the log normalizing constant
+        of $\\textsf{target.logw_next}$. With a proposal $q$, the returned weight
+        is the importance weight
+        $\\textsf{target.logw_next}[x_n] - \\log q_{\\text{norm}}(x_n)$.
 
         Returns:
             (token, weight, logp): A tuple containing the sampled token, weight, and log-probability of the sampled token.
         """
-        logws = await self.potential.logw_next(context)
-        logps = logws.normalize()
+        if self.proposal is None:
+            logws = await self.potential.logw_next(context)
+            logps = logws.normalize()
+            if draw is None:
+                # fast sampling from logps using gumbel-max trick
+                token = fast_sample_lazyweights(logps)
+            else:
+                token = draw(logps.exp().materialize())
+            return token, logws.sum(), logps[token]
+
+        proposal_logws = await self.proposal.logw_next(context)
+        proposal_logps = proposal_logws.normalize()
         if draw is None:
-            # fast sampling from logps using gumbel-max trick
-            token = fast_sample_lazyweights(logps)
+            token = fast_sample_lazyweights(proposal_logps)
         else:
-            token = draw(logps.exp().materialize())
-        return token, logws.sum(), logps[token]
+            token = draw(proposal_logps.exp().materialize())
+        target_logws = await self.potential.logw_next(context)
+        logw = (
+            target_logws[token]
+            - proposal_logws[token]
+            + proposal_logws.sum()
+        )
+        return token, logw, proposal_logps[token]
 
     async def cleanup(self):
         pass  # pragma: no cover
@@ -202,6 +230,15 @@ class AWRS(TokenSampler):
         max_accepts (int): The maximum number of tokens to accept - higher values will decrease the variance of the weight estimate.
         max_rejects (int or float('inf')): The maximum number of tokens to reject - lower values will run faster, but at the cost of returning a weight of zero for some samples where there are tokens that would be accepted if tested.
         n_monte_carlo_samples (int): The number of Monte Carlo samples to use to estimate the weight. Higher values will decrease the variance of the weight estimate, but will run slower.
+        proposal (Potential, optional): If supplied, the rejection loop proposes
+            from `proposal.logw_next` instead of `potential.logw_next`, and the
+            returned weight is corrected by `target/proposal` so the sample stays
+            properly weighted with respect to `(potential * condition).logw_next`.
+            Must share `potential.vocab_eos` (cross-tokenizer not supported). With
+            `proper_weights=False`, the proposal still steers sampling but no
+            correction is applied (matching the `proper_weights=False` contract).
+            The proposal must place positive mass on every token the target
+            weights positively.
     """
 
     def __init__(
@@ -214,10 +251,14 @@ class AWRS(TokenSampler):
         max_accepts=2,
         max_rejects=float("inf"),
         n_monte_carlo_samples=None,
+        proposal=None,
     ):
         super().__init__(target=potential * condition)
         self.potential = potential
         self.condition = condition
+        if proposal is not None:
+            _validate_proposal_vocab(potential, proposal)
+        self.proposal = proposal
 
         self.prune_logws = prune_logws
         self.proper_weights = proper_weights
@@ -279,12 +320,21 @@ class AWRS(TokenSampler):
     async def sample(self, context, verbosity=0):
         """Sample a token and weight that are properly weighted with respect to the target potential's `logw_next` method via adaptive weighted rejection sampling.
 
-        The returned weight corresponds to the log normalizing constant of $\\textsf{target.logw_next}(x_n | x_1, \\ldots, x_{n-1})$.
+        With no proposal, the returned weight is the log normalizing constant of
+        $\\textsf{target.logw_next}$. With a proposal $q$, the inner loop proposes
+        from $q$ and the returned weight adds an importance correction
+        $\\textsf{potential.logw_next}[x_n] - q.\\textsf{logw_next}[x_n]$.
 
         Returns:
             (token, weight, np.nan): A tuple containing the sampled token, weight, and a dummy value for the log-probability of the sampled token.
         """
-        logws = await self.potential.logw_next(context)
+        if self.proposal is None:
+            logws = await self.potential.logw_next(context)
+            target_logws = None
+        else:
+            target_logws = await self.potential.logw_next(context)
+            logws = await self.proposal.logw_next(context)
+
         if self.prune_logws:
             logws = self._prune_logws(logws)
 
@@ -340,7 +390,6 @@ class AWRS(TokenSampler):
                 max_rejects=self.max_rejects,
                 max_accepts=self.max_accepts,
             )
-            return tok, w + logZ, np.nan
         else:
             tok, w, _ = await recursive_awrs(
                 logps=logps,
@@ -349,7 +398,16 @@ class AWRS(TokenSampler):
                 rng=self.rng,
                 max_rejects=self.max_rejects,
             )
+
+        if target_logws is None:
             return tok, w + logZ, np.nan
+
+        # `tok` was drawn with finite sampling weight, so `_prune_logws` left
+        # `logws.weights[tok_idx]` untouched even when pruning is on. When
+        # `w == -inf` (rejection failure) the result stays -inf.
+        tok_idx = self.potential.lookup[tok]
+        log_ratio = target_logws.weights[tok_idx] - logws.weights[tok_idx]
+        return tok, w + logZ + log_ratio, np.nan
 
 
 # If the top log probability exceeds this value, then it will be

--- a/genlm/control/sampler/util.py
+++ b/genlm/control/sampler/util.py
@@ -1,0 +1,18 @@
+"""Internal helpers shared by token samplers."""
+from genlm.control.potential.base import Potential
+
+
+def _validate_proposal_vocab(target_potential, proposal):
+    """Require `proposal.vocab_eos` to match `target_potential.vocab_eos`
+    token-for-token. Cross-tokenizer proposals are not yet supported."""
+    if not isinstance(proposal, Potential):
+        raise TypeError(
+            f"`proposal` must be a Potential; got {type(proposal).__name__}."
+        )
+    if proposal.vocab_eos != target_potential.vocab_eos:
+        raise ValueError(
+            "Proposal must share the target potential's `vocab_eos` "
+            "(token-for-token); cross-tokenizer proposals are not yet supported. "
+            f"Target has {len(target_potential.vocab_eos)} tokens; proposal has "
+            f"{len(proposal.vocab_eos)}."
+        )

--- a/genlm/control/sampler/util.py
+++ b/genlm/control/sampler/util.py
@@ -11,8 +11,7 @@ def _validate_proposal_vocab(target_potential, proposal):
         )
     if proposal.vocab_eos != target_potential.vocab_eos:
         raise ValueError(
-            "Proposal must share the target potential's `vocab_eos` "
-            "(token-for-token); cross-tokenizer proposals are not yet supported. "
+            "Proposals with different tokenizers are not yet supported. "
             f"Target has {len(target_potential.vocab_eos)} tokens; proposal has "
             f"{len(proposal.vocab_eos)}."
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,27 @@ class MockPotential(Potential):
         return self.make_lazy_weights(self.next_token_logws)
 
 
+class ContextSensitiveMockPotential(Potential):
+    """A mock potential whose logw_next depends on context length,
+    simulating different prompt/conditioning lengths."""
+
+    def __init__(self, vocab, base_logws, context_scale=0.5):
+        self.base_logws = np.array(base_logws)
+        self.context_scale = context_scale
+        super().__init__(vocab)
+
+    async def prefix(self, context):
+        return sum(self.base_logws[self.lookup[t]] for t in context)
+
+    async def complete(self, context):
+        return await self.prefix(context) + self.base_logws[-1]
+
+    async def logw_next(self, context):
+        # Scale weights by context length to make them context-dependent
+        scale = 1.0 + self.context_scale * len(context)
+        return self.make_lazy_weights(self.base_logws * scale)
+
+
 @st.composite
 def mock_vocab(draw):
     item_strategy = draw(

--- a/tests/sampler/test_awrs.py
+++ b/tests/sampler/test_awrs.py
@@ -560,7 +560,7 @@ def test_awrs_proposal_vocab_mismatch():
         [bytes([i]) for i in range(3)],
         np.log([0.5, 0.3, 0.1, 0.1]),
     )
-    with pytest.raises(ValueError, match="vocab_eos"):
+    with pytest.raises(ValueError, match="different tokenizers"):
         AWRS(potential, condition, proposal=different_vocab)
 
 
@@ -575,6 +575,98 @@ def test_awrs_proposal_must_be_potential():
     )
     with pytest.raises(TypeError, match="Potential"):
         AWRS(potential, condition, proposal=object())
+
+
+@pytest.mark.asyncio
+async def test_awrs_proposal_rejection_returns_neg_inf():
+    """When the condition rejects all tokens, the final weight must be -inf
+    even with a proposal (the log_ratio correction must not rescue it)."""
+    vocab = [bytes([i]) for i in range(4)]
+    potential = MockPotential(vocab, np.log([0.1, 0.2, 0.3, 0.3, 0.1]))
+    proposal = MockPotential(vocab, np.log([0.4, 0.1, 0.1, 0.3, 0.1]))
+    # Condition rejects everything
+    condition = MockPotential(vocab, [float("-inf")] * 5)
+
+    sampler = AWRS(potential, condition, proposal=proposal, seed=0)
+    for _ in range(50):
+        tok, logw, _ = await sampler.sample([])
+        assert logw == float("-inf"), (
+            f"Expected -inf weight when all tokens rejected, got {logw}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_awrs_proposal_partial_rejection_neg_inf():
+    """When a proposal is used and the sampled token happens to be rejected,
+    the weight is -inf. When accepted, the weight is finite."""
+    vocab = [bytes([i]) for i in range(4)]
+    potential = MockPotential(vocab, np.log([0.1, 0.2, 0.3, 0.3, 0.1]))
+    proposal = MockPotential(vocab, np.log([0.4, 0.1, 0.1, 0.3, 0.1]))
+    # Only first two tokens are valid
+    condition = MockPotential(vocab, [0, 0, float("-inf"), float("-inf"), 0])
+
+    sampler = AWRS(potential, condition, proposal=proposal, seed=42)
+    saw_finite = False
+    for _ in range(200):
+        tok, logw, _ = await sampler.sample([])
+        if logw > float("-inf"):
+            saw_finite = True
+            assert np.isfinite(logw), f"Expected finite weight, got {logw}"
+        else:
+            assert logw == float("-inf")
+    assert saw_finite, "Expected at least one finite-weight sample"
+
+
+@pytest.mark.asyncio
+async def test_awrs_proposal_with_pruning_is_unbiased():
+    """With prune_logws=True and a proposal, pruning zeros out proposal weights
+    for tokens outside the condition's support, but the IS correction via
+    log_ratio (target/proposal) must still yield an unbiased estimator."""
+    vocab = [bytes([i]) for i in range(5)]
+    potential = MockPotential(
+        vocab, np.log([0.15, 0.25, 0.20, 0.15, 0.15, 0.10])
+    )
+    proposal = MockPotential(
+        vocab, np.log([0.30, 0.10, 0.10, 0.20, 0.20, 0.10])
+    )
+    # Condition accepts tokens 0, 1, 2 and EOS; rejects 3, 4
+    condition = MockPotential(
+        vocab, [0, 0, 0, float("-inf"), float("-inf"), 0]
+    )
+
+    sampler = AWRS(
+        potential, condition, proposal=proposal, prune_logws=True, seed=0
+    )
+
+    want = await sampler.target.logw_next([])
+    have = await monte_carlo(sampler, [], 10000)
+
+    assert np.isclose(np.exp(want.sum()), np.exp(have.sum()), rtol=3e-2, atol=3e-2)
+
+
+@pytest.mark.asyncio
+async def test_awrs_proposal_without_pruning_is_unbiased():
+    """Same as above but with prune_logws=False: the _accept function
+    (not pruning) filters invalid tokens, and IS correction still holds."""
+    vocab = [bytes([i]) for i in range(5)]
+    potential = MockPotential(
+        vocab, np.log([0.15, 0.25, 0.20, 0.15, 0.15, 0.10])
+    )
+    proposal = MockPotential(
+        vocab, np.log([0.30, 0.10, 0.10, 0.20, 0.20, 0.10])
+    )
+    condition = MockPotential(
+        vocab, [0, 0, 0, float("-inf"), float("-inf"), 0]
+    )
+
+    sampler = AWRS(
+        potential, condition, proposal=proposal, prune_logws=False, seed=0
+    )
+
+    want = await sampler.target.logw_next([])
+    have = await monte_carlo(sampler, [], 10000)
+
+    assert np.isclose(np.exp(want.sum()), np.exp(have.sum()), rtol=3e-2, atol=3e-2)
 
 
 @pytest.mark.parametrize(

--- a/tests/sampler/test_awrs.py
+++ b/tests/sampler/test_awrs.py
@@ -422,6 +422,161 @@ async def test_awrs_does_not_return_zero_weight_in_default_configuration(
         assert logp == float("-inf")
 
 
+async def assert_monte_carlo_close_with_proposal(
+    params,
+    proposal_ws,
+    N,
+    equality_opts={},
+    sampler_opts={},
+):
+    """`assert_monte_carlo_close` variant that constructs AWRS with an explicit
+    proposal over the same vocab as the potential."""
+    vocab, b_weights, c_weights = params
+    potential = MockPotential(
+        vocab,
+        np.array([np.log(w) if w > 0 else float("-inf") for w in c_weights]),
+    )
+    condition = MockPotential(
+        vocab,
+        np.array([np.log(w) if w > 0 else float("-inf") for w in b_weights]),
+    )
+    proposal = MockPotential(
+        vocab,
+        np.array([np.log(w) if w > 0 else float("-inf") for w in proposal_ws]),
+    )
+    sampler = AWRS(potential, condition, proposal=proposal, **sampler_opts)
+
+    want = await sampler.target.logw_next([])
+    have = await monte_carlo(sampler, [], N)
+
+    assert np.isclose(np.exp(want.sum()), np.exp(have.sum()), **equality_opts)
+
+
+@pytest.mark.asyncio
+@settings(deadline=None, max_examples=15)
+@given(params())
+async def test_awrs_with_uniform_proposal_is_unbiased(params):
+    """AWRS recovers `target.logw_next` from a uniform proposal."""
+    vocab, b_weights, c_weights = params
+    # Skip degenerate target (no valid mass): the existing tests cover that case
+    # and here we want a meaningful Monte-Carlo signal.
+    assume(any(b and c > 0 for b, c in zip(b_weights, c_weights)))
+
+    n = len(vocab) + 1
+    uniform = [1.0 / n] * n
+
+    await assert_monte_carlo_close_with_proposal(
+        params=params,
+        proposal_ws=uniform,
+        N=10000,
+        equality_opts={"rtol": 3e-2, "atol": 3e-2},
+    )
+
+
+@pytest.mark.asyncio
+@settings(deadline=None, max_examples=15)
+@given(params())
+async def test_awrs_with_perturbed_proposal_is_unbiased(params):
+    """AWRS recovers `target.logw_next` from a sqrt-reshaped proposal
+    (same support as the target, different mass)."""
+    vocab, b_weights, c_weights = params
+    assume(any(b and c > 0 for b, c in zip(b_weights, c_weights)))
+
+    perturbed = [float(np.sqrt(w)) for w in c_weights]
+
+    await assert_monte_carlo_close_with_proposal(
+        params=params,
+        proposal_ws=perturbed,
+        N=10000,
+        equality_opts={"rtol": 3e-2, "atol": 3e-2},
+    )
+
+
+@pytest.mark.asyncio
+@settings(deadline=None, max_examples=10)
+@given(params())
+async def test_awrs_with_proposal_and_no_pruning(params):
+    """Proposal + `prune_logws=False`: IS correction still unbiased when
+    `_accept` (not pruning) filters invalid tokens."""
+    vocab, b_weights, c_weights = params
+    assume(any(b and c > 0 for b, c in zip(b_weights, c_weights)))
+
+    perturbed = [float(np.sqrt(w)) for w in c_weights]
+    await assert_monte_carlo_close_with_proposal(
+        params=params,
+        proposal_ws=perturbed,
+        N=10000,
+        equality_opts={"rtol": 3e-2, "atol": 3e-2},
+        sampler_opts={"prune_logws": False},
+    )
+
+
+@pytest.mark.asyncio
+async def test_awrs_with_proposal_and_improper_weights_returns_zero_or_minus_inf():
+    """`proper_weights=False` + proposal: no IS correction; weights are 0 on
+    accept and -inf on reject, by design."""
+    vocab = [bytes([i]) for i in range(4)]
+    potential = MockPotential(vocab, np.log([0.10, 0.20, 0.30, 0.30, 0.10]))
+    proposal = MockPotential(vocab, np.log([0.40, 0.10, 0.10, 0.30, 0.10]))
+    condition = MockPotential(vocab, [0, 0, float("-inf"), float("-inf"), 0])
+
+    sampler = AWRS(
+        potential, condition, proposal=proposal, proper_weights=False, seed=0
+    )
+    for _ in range(50):
+        tok, logw, _ = await sampler.sample([])
+        assert logw == 0.0 or logw == float("-inf")
+        assert tok in sampler.target.vocab_eos
+
+
+@pytest.mark.asyncio
+async def test_awrs_proposal_none_matches_no_proposal_kwarg():
+    """`AWRS(..., proposal=None)` consumes the same RNG draws as `AWRS(...)` —
+    guards against accidental RNG-consumption changes in the new branch."""
+    vocab = [bytes([i]) for i in range(4)]
+    potential = MockPotential(vocab, np.log([0.1, 0.2, 0.3, 0.3, 0.1]))
+    condition = MockPotential(vocab, [0, 0, float("-inf"), float("-inf"), 0])
+
+    N = 5000
+
+    s_default = AWRS(potential, condition, seed=0)
+    s_explicit = AWRS(potential, condition, seed=0, proposal=None)
+
+    h_default = await monte_carlo(s_default, [], N)
+    h_explicit = await monte_carlo(s_explicit, [], N)
+    np.testing.assert_array_equal(h_default.weights, h_explicit.weights)
+
+
+def test_awrs_proposal_vocab_mismatch():
+    potential = MockPotential(
+        [bytes([i]) for i in range(4)],
+        np.log([0.4, 0.3, 0.1, 0.1, 0.1]),
+    )
+    condition = MockPotential(
+        [bytes([i]) for i in range(4)],
+        [0, 0, float("-inf"), float("-inf"), 0],
+    )
+    different_vocab = MockPotential(
+        [bytes([i]) for i in range(3)],
+        np.log([0.5, 0.3, 0.1, 0.1]),
+    )
+    with pytest.raises(ValueError, match="vocab_eos"):
+        AWRS(potential, condition, proposal=different_vocab)
+
+
+def test_awrs_proposal_must_be_potential():
+    potential = MockPotential(
+        [bytes([i]) for i in range(4)],
+        np.log([0.4, 0.3, 0.1, 0.1, 0.1]),
+    )
+    condition = MockPotential(
+        [bytes([i]) for i in range(4)],
+        [0, 0, float("-inf"), float("-inf"), 0],
+    )
+    with pytest.raises(TypeError, match="Potential"):
+        AWRS(potential, condition, proposal=object())
+
+
 @pytest.mark.parametrize(
     "params",
     [

--- a/tests/sampler/test_token_sampler.py
+++ b/tests/sampler/test_token_sampler.py
@@ -1,6 +1,8 @@
+import asyncio
 import pytest
 import tempfile
 import numpy as np
+from arsenal.maths import logsumexp
 
 from genlm.control.sampler import DirectTokenSampler, SetTokenSampler, EagerSetSampler
 from conftest import (
@@ -28,6 +30,103 @@ async def test_direct_token_sampler(params):
         have.assert_equal(want, atol=1e-5, rtol=1e-5)
     finally:
         await sampler.cleanup()
+
+
+@st.composite
+def _mock_params_with_proposal(draw, max_w=1e3):
+    """Vocab + two independent positive weight vectors (target / proposal) + a context."""
+    vocab = draw(mock_vocab())
+    n = len(vocab) + 1
+    target_ws = draw(
+        st.lists(st.floats(1e-3, max_w), min_size=n, max_size=n)
+    )
+    proposal_ws = draw(
+        st.lists(st.floats(1e-3, max_w), min_size=n, max_size=n)
+    )
+    context = draw(st.lists(st.sampled_from(vocab), min_size=0, max_size=5))
+    return vocab, target_ws, proposal_ws, context
+
+
+@pytest.mark.asyncio
+@settings(deadline=None, max_examples=25)
+@given(_mock_params_with_proposal())
+async def test_direct_token_sampler_with_proposal_swor(params):
+    """SWOR enumeration recovers `target.logw_next` under an arbitrary
+    same-vocab, fully-supported proposal."""
+    vocab, target_ws, proposal_ws, context = params
+    target = MockPotential(vocab, np.log(target_ws))
+    proposal = MockPotential(vocab, np.log(proposal_ws))
+    sampler = DirectTokenSampler(target, proposal=proposal)
+
+    try:
+        have = await trace_swor(sampler, context)
+        want = await sampler.target.logw_next(context)
+        have.assert_equal(want, atol=1e-5, rtol=1e-5)
+    finally:
+        await sampler.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_direct_token_sampler_with_proposal_monte_carlo():
+    """IS weighting under a skewed proposal recovers `target.logw_next` via
+    Monte-Carlo; also exercises the Gumbel-max (`draw=None`) path."""
+    vocab = [bytes([i]) for i in range(4)]
+    target_ws = np.array([0.1, 0.2, 0.3, 0.3, 0.1])
+    # Deliberately skewed proposal — supports same tokens but different mass.
+    proposal_ws = np.array([0.4, 0.1, 0.1, 0.3, 0.1])
+
+    target = MockPotential(vocab, np.log(target_ws))
+    proposal = MockPotential(vocab, np.log(proposal_ws))
+    sampler = DirectTokenSampler(target, proposal=proposal)
+
+    N = 20_000
+    samples = await asyncio.gather(*[sampler.sample([]) for _ in range(N)])
+
+    logws = sampler.target.alloc_logws()
+    for tok, logw, _ in samples:
+        if logw == float("-inf"):
+            continue
+        tid = sampler.target.lookup[tok]
+        logws[tid] = (
+            logw - np.log(N) if logws[tid] == float("-inf")
+            else logsumexp([logws[tid], logw - np.log(N)])
+        )
+
+    want = await sampler.target.logw_next([])
+    have = sampler.target.make_lazy_weights(logws)
+    np.testing.assert_allclose(
+        np.exp(have.weights), np.exp(want.weights), rtol=5e-2, atol=5e-2
+    )
+
+
+def test_direct_token_sampler_proposal_vocab_mismatch():
+    target = MockPotential([bytes([i]) for i in range(3)], np.log([0.3, 0.3, 0.3, 0.1]))
+    different_vocab = MockPotential(
+        [bytes([i]) for i in range(2)], np.log([0.4, 0.4, 0.2])
+    )
+    with pytest.raises(ValueError, match="vocab_eos"):
+        DirectTokenSampler(target, proposal=different_vocab)
+
+
+def test_direct_token_sampler_proposal_must_be_potential():
+    target = MockPotential([bytes([i]) for i in range(3)], np.log([0.3, 0.3, 0.3, 0.1]))
+    with pytest.raises(TypeError, match="Potential"):
+        DirectTokenSampler(target, proposal=object())
+
+
+def test_direct_token_sampler_factory_threads_proposal():
+    """`direct_token_sampler` forwards `proposal` to `DirectTokenSampler`."""
+    from genlm.control.sampler import direct_token_sampler
+
+    vocab = [bytes([i]) for i in range(3)]
+    target = MockPotential(vocab, np.log([0.3, 0.3, 0.3, 0.1]))
+    proposal = MockPotential(vocab, np.log([0.4, 0.3, 0.2, 0.1]))
+
+    s_default = direct_token_sampler(target)
+    s_with_proposal = direct_token_sampler(target, proposal=proposal)
+
+    assert s_default.proposal is None
+    assert s_with_proposal.proposal is proposal
 
 
 @pytest.mark.asyncio

--- a/tests/sampler/test_token_sampler.py
+++ b/tests/sampler/test_token_sampler.py
@@ -9,6 +9,7 @@ from conftest import (
     mock_params,
     iter_item_params,
     MockPotential,
+    ContextSensitiveMockPotential,
     trace_swor,
     mock_vocab,
 )
@@ -99,12 +100,51 @@ async def test_direct_token_sampler_with_proposal_monte_carlo():
     )
 
 
+@pytest.mark.asyncio
+async def test_direct_token_sampler_with_proposal_exact_weight():
+    """Verify the exact weight formula for a single sample with a proposal:
+    logw = target_logws[token] - proposal_logps[token]
+         = target_logws[token] - proposal_logws[token] + log(Z_proposal)
+    """
+    vocab = [bytes([i]) for i in range(3)]
+    target_ws = np.array([0.2, 0.5, 0.1, 0.2])
+    proposal_ws = np.array([0.4, 0.1, 0.3, 0.2])
+
+    target = MockPotential(vocab, np.log(target_ws))
+    proposal = MockPotential(vocab, np.log(proposal_ws))
+    sampler = DirectTokenSampler(target, proposal=proposal)
+
+    # Use draw to deterministically pick each token and check its weight.
+    target_logws = np.log(target_ws)
+    proposal_logws = np.log(proposal_ws)
+    log_Z_proposal = logsumexp(proposal_logws)
+    proposal_logps = proposal_logws - log_Z_proposal
+
+    for forced_idx in range(len(target_ws)):
+        forced_token = sampler.target.vocab_eos[forced_idx]
+
+        def draw(p, _tok=forced_token):
+            # Return a specific token regardless of the distribution.
+            return _tok
+
+        tok, logw, logp = await sampler.sample([], draw=draw)
+        tid = sampler.target.lookup[tok]
+        assert tid == forced_idx
+
+        expected_logw = target_logws[tid] - proposal_logws[tid] + log_Z_proposal
+        np.testing.assert_allclose(logw, expected_logw, rtol=1e-10)
+
+        expected_logp = proposal_logps[tid]
+        np.testing.assert_allclose(logp, expected_logp, rtol=1e-10)
+
+
+
 def test_direct_token_sampler_proposal_vocab_mismatch():
     target = MockPotential([bytes([i]) for i in range(3)], np.log([0.3, 0.3, 0.3, 0.1]))
     different_vocab = MockPotential(
         [bytes([i]) for i in range(2)], np.log([0.4, 0.4, 0.2])
     )
-    with pytest.raises(ValueError, match="vocab_eos"):
+    with pytest.raises(ValueError, match="different tokenizers"):
         DirectTokenSampler(target, proposal=different_vocab)
 
 
@@ -151,6 +191,129 @@ async def test_set_token_sampler(params):
         have.assert_equal(want, atol=1e-5, rtol=1e-5)
     finally:
         await sampler.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_direct_token_sampler_proposal_different_distributions():
+    """When target and proposal have different context-dependent distributions
+    (simulating e.g. different prompt lengths / conditioning), the IS weight
+    formula still holds exactly for each token."""
+    vocab = [bytes([i]) for i in range(3)]
+    target_base = np.log([0.3, 0.4, 0.2, 0.1])
+    proposal_base = np.log([0.1, 0.1, 0.5, 0.3])
+
+    target = ContextSensitiveMockPotential(vocab, target_base, context_scale=0.3)
+    proposal = ContextSensitiveMockPotential(vocab, proposal_base, context_scale=0.7)
+    sampler = DirectTokenSampler(target, proposal=proposal)
+
+    # Test with several different context lengths
+    for ctx in [[], [vocab[0]], [vocab[0], vocab[1]], [vocab[0], vocab[1], vocab[2]]]:
+        target_logws_ctx = await target.logw_next(ctx)
+        proposal_logws_ctx = await proposal.logw_next(ctx)
+
+        proposal_log_Z = logsumexp(proposal_logws_ctx.weights)
+        proposal_logps = proposal_logws_ctx.weights - proposal_log_Z
+
+        for forced_idx in range(len(target_base)):
+            forced_token = sampler.target.vocab_eos[forced_idx]
+
+            def draw(p, _tok=forced_token):
+                return _tok
+
+            tok, logw, logp = await sampler.sample(ctx, draw=draw)
+            tid = sampler.target.lookup[tok]
+            assert tid == forced_idx
+
+            expected_logw = (
+                target_logws_ctx.weights[tid]
+                - proposal_logws_ctx.weights[tid]
+                + proposal_log_Z
+            )
+            np.testing.assert_allclose(logw, expected_logw, rtol=1e-10)
+            np.testing.assert_allclose(logp, proposal_logps[tid], rtol=1e-10)
+
+
+@pytest.mark.asyncio
+async def test_direct_token_sampler_proposal_different_distributions_monte_carlo():
+    """Monte Carlo IS estimation converges when target and proposal have
+    context-dependent weights (different effective distributions per context)."""
+    vocab = [bytes([i]) for i in range(3)]
+    target_base = np.log([0.3, 0.4, 0.2, 0.1])
+    proposal_base = np.log([0.1, 0.1, 0.5, 0.3])
+
+    target = ContextSensitiveMockPotential(vocab, target_base, context_scale=0.3)
+    proposal = ContextSensitiveMockPotential(vocab, proposal_base, context_scale=0.7)
+    sampler = DirectTokenSampler(target, proposal=proposal)
+
+    context = [vocab[0], vocab[1]]  # Non-empty context
+
+    N = 20_000
+    samples = [await sampler.sample(context) for _ in range(N)]
+
+    logws_accum = sampler.target.alloc_logws()
+    for tok, logw, _ in samples:
+        if logw == float("-inf"):
+            continue
+        tid = sampler.target.lookup[tok]
+        logws_accum[tid] = (
+            logw - np.log(N) if logws_accum[tid] == float("-inf")
+            else logsumexp([logws_accum[tid], logw - np.log(N)])
+        )
+
+    want = await sampler.target.logw_next(context)
+    have = sampler.target.make_lazy_weights(logws_accum)
+    np.testing.assert_allclose(
+        np.exp(have.weights), np.exp(want.weights), rtol=5e-2, atol=5e-2
+    )
+
+
+@pytest.mark.asyncio
+async def test_sis_with_proposal_weights_match_manual_computation():
+    """SIS (ess_threshold=0) with a proposal: verify each particle's final
+    log-weight matches the manually computed importance weight.
+
+    For DirectTokenSampler with proposal, the per-step log-weight is
+        logw_t = target_logws[tok] - proposal_logws[tok] + logsumexp(proposal_logws)
+    and start_weight = target.prefix([]) = 0 for MockPotential.
+
+    The final particle weight should equal:
+        start_weight + sum_t logw_t
+    """
+    from genlm.control.constant import EOS
+
+    vocab = [bytes([i]) for i in range(3)]
+    target_ws = np.log([0.3, 0.4, 0.2, 0.1])
+    proposal_ws = np.log([0.1, 0.1, 0.5, 0.3])
+
+    target = MockPotential(vocab, target_ws)
+    proposal = MockPotential(vocab, proposal_ws)
+
+    proposal_logZ = logsumexp(proposal_ws)
+
+    seqs = await DirectTokenSampler(target, proposal=proposal).smc(
+        n_particles=10,
+        ess_threshold=0.0,
+        max_tokens=5,
+    )
+
+    # start_weight for MockPotential is prefix([]) = 0
+    start_weight = 0.0
+
+    for ctx, actual_logw in zip(seqs.contexts, seqs.log_weights):
+        # Manually compute the expected final weight
+        expected_logw = start_weight
+        for tok in ctx:
+            if tok is EOS:
+                tid = len(vocab)  # EOS is the last index
+            else:
+                tid = target.lookup[tok]
+            step_logw = target_ws[tid] - proposal_ws[tid] + proposal_logZ
+            expected_logw += step_logw
+
+        np.testing.assert_allclose(
+            actual_logw, expected_logw, rtol=1e-10,
+            err_msg=f"Weight mismatch for sequence {ctx}",
+        )
 
 
 @st.composite
@@ -218,3 +381,36 @@ async def test_smc_token_sampler(params):
         )
         assert len(sequences) == 10
         assert all(len(seq) <= 10 for seq in sequences)
+
+
+@pytest.mark.asyncio
+@settings(deadline=None)
+@given(mock_vocab_and_logws())
+async def test_smc_token_sampler_with_proposal(params):
+    """SMC end-to-end with a proposal-equipped DirectTokenSampler produces
+    valid sequences and propagates logw/logp correctly through forward()."""
+    vocab, logws, logws2 = params
+    target = MockPotential(vocab, logws)
+    proposal = MockPotential(vocab, logws2)
+
+    # Without critic
+    sampler = DirectTokenSampler(target, proposal=proposal)
+    sequences = await sampler.smc(
+        n_particles=10,
+        ess_threshold=0.5,
+        max_tokens=10,
+    )
+    assert len(sequences) == 10
+    assert all(len(seq) <= 10 for seq in sequences)
+
+    # With critic
+    mock_critic = MockPotential(vocab, logws2)
+    sampler = DirectTokenSampler(target, proposal=proposal)
+    sequences = await sampler.smc(
+        n_particles=10,
+        ess_threshold=0.5,
+        max_tokens=10,
+        critic=mock_critic,
+    )
+    assert len(sequences) == 10
+    assert all(len(seq) <= 10 for seq in sequences)

--- a/tests/sampler/test_token_sampler.py
+++ b/tests/sampler/test_token_sampler.py
@@ -169,6 +169,44 @@ def test_direct_token_sampler_factory_threads_proposal():
     assert s_with_proposal.proposal is proposal
 
 
+class _TrackedPotential(MockPotential):
+    """Records peak in-flight `logw_next` calls in a shared tracker.
+    The `sleep(0)` yields the loop so a sibling coroutine can also enter."""
+
+    def __init__(self, vocab, next_token_logws, tracker):
+        super().__init__(vocab, next_token_logws)
+        self._tracker = tracker
+
+    async def logw_next(self, context):
+        self._tracker["in_flight"] += 1
+        self._tracker["peak"] = max(self._tracker["peak"], self._tracker["in_flight"])
+        await asyncio.sleep(0)
+        self._tracker["in_flight"] -= 1
+        return await super().logw_next(context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sampler_cls", ["direct", "awrs"])
+async def test_proposal_logw_next_runs_concurrently(sampler_cls):
+    """Target and proposal `logw_next` must overlap (peak=2). Sequential
+    `await; await` would give peak=1."""
+    from genlm.control.sampler import DirectTokenSampler, AWRS
+
+    vocab = [bytes([i]) for i in range(3)]
+    tracker = {"in_flight": 0, "peak": 0}
+    target = _TrackedPotential(vocab, np.log([0.3, 0.4, 0.2, 0.1]), tracker)
+    proposal = _TrackedPotential(vocab, np.log([0.1, 0.1, 0.5, 0.3]), tracker)
+
+    if sampler_cls == "direct":
+        sampler = DirectTokenSampler(target, proposal=proposal)
+    else:
+        condition = MockPotential(vocab, [0.0, 0.0, 0.0, float("-inf")])
+        sampler = AWRS(target, condition, proposal=proposal, seed=0)
+
+    await sampler.sample([])
+    assert tracker["peak"] == 2
+
+
 @pytest.mark.asyncio
 @settings(deadline=None)
 @given(iter_item_params())

--- a/tests/sampler/test_token_sampler.py
+++ b/tests/sampler/test_token_sampler.py
@@ -268,23 +268,32 @@ async def test_direct_token_sampler_proposal_different_distributions_monte_carlo
 
 
 @pytest.mark.asyncio
-async def test_sis_with_proposal_weights_match_manual_computation():
-    """SIS (ess_threshold=0) with a proposal: verify each particle's final
-    log-weight matches the manually computed importance weight.
+@pytest.mark.parametrize(
+    "target_ws, proposal_ws",
+    [
+        # cross-distribution — IS weight differs from logZ_target per step.
+        (np.log([0.3, 0.4, 0.2, 0.1]), np.log([0.1, 0.1, 0.5, 0.3])),
+        # proposal == target — IS correction collapses to logZ_target.
+        (np.log([0.3, 0.4, 0.2, 0.1]), np.log([0.3, 0.4, 0.2, 0.1])),
+        # peaked target, near-uniform proposal.
+        (np.log([0.6, 0.1, 0.1, 0.2]), np.log([0.25, 0.25, 0.25, 0.25])),
+    ],
+)
+async def test_sis_with_proposal_weights_match_manual_computation(
+    target_ws, proposal_ws
+):
+    """SIS (ess_threshold=0) with a proposal: each particle's final log-weight
+    equals start_weight + sum_t (target_logws[tok_t] - proposal_logws[tok_t]
+    + logsumexp(proposal_logws)).
 
-    For DirectTokenSampler with proposal, the per-step log-weight is
-        logw_t = target_logws[tok] - proposal_logws[tok] + logsumexp(proposal_logws)
-    and start_weight = target.prefix([]) = 0 for MockPotential.
-
-    The final particle weight should equal:
-        start_weight + sum_t logw_t
+    `ess_threshold=0` disables resampling so weights propagate intact through
+    SMC, letting us check the IS formula exactly. Parametrized over several
+    (target, proposal) pairs so a silently-dropped proposal or wrong-sign
+    correction is caught regardless of which token happens to be drawn.
     """
     from genlm.control.constant import EOS
 
     vocab = [bytes([i]) for i in range(3)]
-    target_ws = np.log([0.3, 0.4, 0.2, 0.1])
-    proposal_ws = np.log([0.1, 0.1, 0.5, 0.3])
-
     target = MockPotential(vocab, target_ws)
     proposal = MockPotential(vocab, proposal_ws)
 
@@ -296,19 +305,12 @@ async def test_sis_with_proposal_weights_match_manual_computation():
         max_tokens=5,
     )
 
-    # start_weight for MockPotential is prefix([]) = 0
-    start_weight = 0.0
-
     for ctx, actual_logw in zip(seqs.contexts, seqs.log_weights):
-        # Manually compute the expected final weight
-        expected_logw = start_weight
+        # start_weight = target.prefix([]) = 0 for MockPotential.
+        expected_logw = 0.0
         for tok in ctx:
-            if tok is EOS:
-                tid = len(vocab)  # EOS is the last index
-            else:
-                tid = target.lookup[tok]
-            step_logw = target_ws[tid] - proposal_ws[tid] + proposal_logZ
-            expected_logw += step_logw
+            tid = len(vocab) if tok is EOS else target.lookup[tok]
+            expected_logw += target_ws[tid] - proposal_ws[tid] + proposal_logZ
 
         np.testing.assert_allclose(
             actual_logw, expected_logw, rtol=1e-10,
@@ -387,13 +389,15 @@ async def test_smc_token_sampler(params):
 @settings(deadline=None)
 @given(mock_vocab_and_logws())
 async def test_smc_token_sampler_with_proposal(params):
-    """SMC end-to-end with a proposal-equipped DirectTokenSampler produces
-    valid sequences and propagates logw/logp correctly through forward()."""
+    """Smoke test: proposal-equipped DirectTokenSampler runs end-to-end
+    through SMC with resampling (ess_threshold=0.5) and with a critic.
+    Weight correctness is verified by `test_sis_with_proposal_weights_match_manual_computation`
+    (which uses ess_threshold=0.0); this test only guards against crashes
+    in the resampling + critic code paths when a proposal is in play."""
     vocab, logws, logws2 = params
     target = MockPotential(vocab, logws)
     proposal = MockPotential(vocab, logws2)
 
-    # Without critic
     sampler = DirectTokenSampler(target, proposal=proposal)
     sequences = await sampler.smc(
         n_particles=10,
@@ -403,7 +407,6 @@ async def test_smc_token_sampler_with_proposal(params):
     assert len(sequences) == 10
     assert all(len(seq) <= 10 for seq in sequences)
 
-    # With critic
     mock_critic = MockPotential(vocab, logws2)
     sampler = DirectTokenSampler(target, proposal=proposal)
     sequences = await sampler.smc(


### PR DESCRIPTION
Add support for proposal distributions in `DirectTokenSampler` and `AWRS`. This allows sampling tokens from a different distribution (the proposal) while maintaining properly weighted samples with respect to the target, via importance weight correction. 

Added a new optional `proposal` argument in `DirectTokenSampler` and `AWRS`. In both cases, when a proposal is provided, tokens are drawn from `proposal.logw_next`.