### PR TITLE
BoolFSA: default to Boolean semiring

### DIFF
--- a/genlm/control/potential/built_in/wfsa.py
+++ b/genlm/control/potential/built_in/wfsa.py
@@ -1,4 +1,6 @@
 import string
+import warnings
+
 import numpy as np
 from arsenal.maths import logsumexp
 
@@ -223,15 +225,18 @@ class WFSA(Potential):
 class BoolFSA(WFSA):
     """Boolean FSA potential. Returns ``0`` for accepted, ``-inf`` for rejected.
 
-    Defaults to a Log-semiring internal representation. Pass
-    ``semiring="boolean"`` to ``from_regex`` for the Boolean-semiring path,
-    which gives correct boolean answers for regexes the default path
-    silently mishandles (typically leading-wildcard regexes over a large
-    alphabet).
+    ``from_regex`` constructs a Boolean-semiring WFSA by default; the
+    ``semiring="log"`` path is deprecated (the Log-semiring FSA closure is
+    unsound because ``Log.star`` is partial).
     """
 
     def __init__(self, wfsa):
-        # Float/Log go through parent (Float -> Log). Boolean stays Boolean.
+        """Initialize the BoolFSA from a WFSA.
+
+        Args:
+            wfsa (genlm_grammar.WFSA): A Float, Log, or Boolean WFSA.
+                Float is converted to Log; Boolean is kept as-is.
+        """
         if wfsa.R is Boolean:
             self.wfsa = wfsa
             self.cache = {(): self.wfsa.epsremove.start}
@@ -240,19 +245,30 @@ class BoolFSA(WFSA):
             super().__init__(wfsa)
 
     @classmethod
-    def from_regex(cls, pattern, charset=None, to_bytes=True, semiring="log"):
+    def from_regex(cls, pattern, charset=None, to_bytes=True, semiring="boolean"):
         """Create a BoolFSA from a regex pattern.
 
         Args:
             pattern (str): regex pattern.
             charset (set): see ``WFSA.from_regex``.
             to_bytes (bool): see ``WFSA.from_regex``.
-            semiring (str): ``"log"`` (default) or ``"boolean"``. Use
-                ``"boolean"`` for regexes the default path silently mishandles.
+            semiring (str): ``"boolean"`` (default) or ``"log"``. ``"log"``
+                is deprecated; its closure is unsound (``Log.star`` is partial).
+
+        Returns:
+            (BoolFSA): An instance of the BoolFSA class.
         """
         if semiring not in ("log", "boolean"):
             raise ValueError(
                 f"semiring must be 'log' or 'boolean', got {semiring!r}"
+            )
+        if semiring == "log":
+            warnings.warn(
+                "semiring='log' is deprecated: the FSA closure is unsound on "
+                "the Log semiring because Log.star is partial. "
+                "Use semiring='boolean'.",
+                DeprecationWarning,
+                stacklevel=2,
             )
         charset = charset or set(string.printable)
         wfsa = interegular_to_wfsa(pattern, charset=charset)
@@ -275,7 +291,14 @@ class BoolFSA(WFSA):
         return super()._prefix(context)
 
     async def prefix(self, context):
-        """``0`` if ``context`` is an accepted prefix, ``-inf`` otherwise."""
+        """Tests whether `context` is accepted as a prefix.
+
+        Args:
+            context (list): A sequence of tokens in the WFSA's alphabet.
+
+        Returns:
+            (float): ``0`` if accepted as a prefix, ``-inf`` otherwise.
+        """
         if self.wfsa.R is Boolean:
             return self._prefix(context)[0]
         prefix_w = await super().prefix(context)
@@ -284,7 +307,14 @@ class BoolFSA(WFSA):
         return float("-inf")
 
     async def complete(self, context):
-        """``0`` if ``context`` is accepted, ``-inf`` otherwise."""
+        """Tests whether `context` is accepted.
+
+        Args:
+            context (list): A sequence of tokens in the WFSA's alphabet.
+
+        Returns:
+            (float): ``0`` if accepted, ``-inf`` otherwise.
+        """
         if self.wfsa.R is Boolean:
             curr = self._consume(context)
             if not curr:
@@ -300,7 +330,15 @@ class BoolFSA(WFSA):
         return float("-inf")
 
     async def logw_next(self, context):
-        """Per-token admissibility log-weights: ``0`` admissible, ``-inf`` not."""
+        """Per-token admissibility log weights given `context`.
+
+        Args:
+            context (list): A sequence of tokens in the WFSA's alphabet.
+
+        Returns:
+            (LazyWeights): ``0`` for admissible next tokens (incl. EOS),
+                ``-inf`` for rejected.
+        """
         if self.wfsa.R is Boolean:
             curr = self._consume(context)
             if not curr:
@@ -325,7 +363,14 @@ class BoolFSA(WFSA):
         )
 
     async def batch_logw_next(self, contexts):
-        """Per-token admissibility log-weights for each context."""
+        """Per-token admissibility log weights for a batch of contexts.
+
+        Args:
+            contexts (list): The list of contexts.
+
+        Returns:
+            (list): List of ``LazyWeights``, one per context.
+        """
         if self.wfsa.R is Boolean:
             return [await self.logw_next(c) for c in contexts]
         logw_nexts = await super().batch_logw_next(contexts)

--- a/genlm/control/potential/built_in/wfsa.py
+++ b/genlm/control/potential/built_in/wfsa.py
@@ -10,11 +10,8 @@ from genlm.control.potential.base import Potential
 
 
 def _float_to_boolean(wfsa):
-    """Convert a Float-semiring WFSA to Boolean: non-zero weights become ``Boolean.one``.
-
-    Same accepted language; ``Boolean.star`` is total so closure has no
-    precision issues.
-    """
+    """Convert a Float-semiring WFSA to Boolean: every non-zero weight
+    becomes ``Boolean.one``. Same accepted language."""
     assert wfsa.R is Float
     new = BaseWFSA(Boolean)
     for i, w in wfsa.I:
@@ -227,10 +224,10 @@ class BoolFSA(WFSA):
     """Boolean FSA potential. Returns ``0`` for accepted, ``-inf`` for rejected.
 
     Defaults to a Log-semiring internal representation. Pass
-    ``semiring="boolean"`` to ``from_regex`` to use the Boolean semiring
-    instead, which avoids ``Log.star``'s precision wall on regexes whose
-    DFA has a near-recurrent SCC (typically leading-wildcard regexes over
-    a large alphabet).
+    ``semiring="boolean"`` to ``from_regex`` for the Boolean-semiring path,
+    which gives correct boolean answers for regexes the default path
+    silently mishandles (typically leading-wildcard regexes over a large
+    alphabet).
     """
 
     def __init__(self, wfsa):
@@ -251,7 +248,7 @@ class BoolFSA(WFSA):
             charset (set): see ``WFSA.from_regex``.
             to_bytes (bool): see ``WFSA.from_regex``.
             semiring (str): ``"log"`` (default) or ``"boolean"``. Use
-                ``"boolean"`` when ``Log.star`` would hit its precision wall.
+                ``"boolean"`` for regexes the default path silently mishandles.
         """
         if semiring not in ("log", "boolean"):
             raise ValueError(
@@ -266,7 +263,6 @@ class BoolFSA(WFSA):
         return cls(wfsa)
 
     def _prefix(self, context):
-        # Boolean path: graph reachability, no Lehmann / Log.star.
         if self.wfsa.R is Boolean:
             curr = self._consume(context)
             if not curr:

--- a/genlm/control/potential/built_in/wfsa.py
+++ b/genlm/control/potential/built_in/wfsa.py
@@ -3,9 +3,30 @@ import numpy as np
 from arsenal.maths import logsumexp
 
 from genlm.grammar import Float, Log, WFSA as BaseWFSA
+from genlm.grammar.semiring import Boolean
 from genlm.grammar.lark_interface import interegular_to_wfsa
 
 from genlm.control.potential.base import Potential
+
+
+def _float_to_boolean(wfsa):
+    """Convert a Float-semiring WFSA to Boolean: non-zero weights become ``Boolean.one``.
+
+    Same accepted language; ``Boolean.star`` is total so closure has no
+    precision issues.
+    """
+    assert wfsa.R is Float
+    new = BaseWFSA(Boolean)
+    for i, w in wfsa.I:
+        if w != 0:
+            new.add_I(i, Boolean.one)
+    for i, w in wfsa.F:
+        if w != 0:
+            new.add_F(i, Boolean.one)
+    for i, a, j, w in wfsa.arcs():
+        if w != 0:
+            new.add_arc(i, a, j, Boolean.one)
+    return new
 
 
 class WFSA(Potential):
@@ -203,48 +224,103 @@ class WFSA(Potential):
 
 
 class BoolFSA(WFSA):
-    """Boolean FSA potential."""
+    """Boolean FSA potential. Returns ``0`` for accepted, ``-inf`` for rejected.
 
-    async def prefix(self, context):
-        """
-        Computes whether the context is accepted as a prefix by the FSA.
+    Defaults to a Log-semiring internal representation. Pass
+    ``semiring="boolean"`` to ``from_regex`` to use the Boolean semiring
+    instead, which avoids ``Log.star``'s precision wall on regexes whose
+    DFA has a near-recurrent SCC (typically leading-wildcard regexes over
+    a large alphabet).
+    """
+
+    def __init__(self, wfsa):
+        # Float/Log go through parent (Float -> Log). Boolean stays Boolean.
+        if wfsa.R is Boolean:
+            self.wfsa = wfsa
+            self.cache = {(): self.wfsa.epsremove.start}
+            Potential.__init__(self, vocabulary=list(self.wfsa.alphabet))
+        else:
+            super().__init__(wfsa)
+
+    @classmethod
+    def from_regex(cls, pattern, charset=None, to_bytes=True, semiring="log"):
+        """Create a BoolFSA from a regex pattern.
 
         Args:
-            context (list): A sequence of tokens in the WFSA's alphabet.
-
-        Returns:
-            (float): `0` if the context is accepted as a prefix, `-inf` otherwise.
+            pattern (str): regex pattern.
+            charset (set): see ``WFSA.from_regex``.
+            to_bytes (bool): see ``WFSA.from_regex``.
+            semiring (str): ``"log"`` (default) or ``"boolean"``. Use
+                ``"boolean"`` when ``Log.star`` would hit its precision wall.
         """
+        if semiring not in ("log", "boolean"):
+            raise ValueError(
+                f"semiring must be 'log' or 'boolean', got {semiring!r}"
+            )
+        charset = charset or set(string.printable)
+        wfsa = interegular_to_wfsa(pattern, charset=charset)
+        if to_bytes:
+            wfsa = wfsa.to_bytes()
+        if semiring == "boolean":
+            wfsa = _float_to_boolean(wfsa)
+        return cls(wfsa)
+
+    def _prefix(self, context):
+        # Boolean path: graph reachability, no Lehmann / Log.star.
+        if self.wfsa.R is Boolean:
+            curr = self._consume(context)
+            if not curr:
+                return float("-inf"), curr
+            bkwd = self.wfsa.epsremove.backward
+            for i in curr:
+                if bkwd[i].score:  # i is co-accessible
+                    return 0.0, curr
+            return float("-inf"), curr
+        return super()._prefix(context)
+
+    async def prefix(self, context):
+        """``0`` if ``context`` is an accepted prefix, ``-inf`` otherwise."""
+        if self.wfsa.R is Boolean:
+            return self._prefix(context)[0]
         prefix_w = await super().prefix(context)
         if prefix_w > float("-inf"):
             return 0
         return float("-inf")
 
     async def complete(self, context):
-        """
-        Computes whether the context is accepted by the FSA.
-
-        Args:
-            context (list): A sequence of tokens in the WFSA's alphabet.
-
-        Returns:
-            (float): `0` if the context is accepted, `-inf` otherwise.
-        """
+        """``0`` if ``context`` is accepted, ``-inf`` otherwise."""
+        if self.wfsa.R is Boolean:
+            curr = self._consume(context)
+            if not curr:
+                return float("-inf")
+            finals = dict(self.wfsa.epsremove.F)
+            for i in curr:
+                if i in finals and finals[i].score:
+                    return 0.0
+            return float("-inf")
         complete_w = await super().complete(context)
         if complete_w > float("-inf"):
             return 0
         return float("-inf")
 
     async def logw_next(self, context):
-        """
-        Returns next token log weights given `context`.
-
-        Args:
-            context (list): A sequence of tokens in the WFSA's alphabet.
-
-        Returns:
-            (LazyWeights): Boolean log-weights for next token.
-        """
+        """Per-token admissibility log-weights: ``0`` admissible, ``-inf`` not."""
+        if self.wfsa.R is Boolean:
+            curr = self._consume(context)
+            if not curr:
+                raise ValueError(f"Context {context!r} has zero weight.")
+            bkwd = self.wfsa.epsremove.backward
+            finals = dict(self.wfsa.epsremove.F)
+            out = self.alloc_logws()
+            for i in curr:
+                for b, j, w in self.wfsa.epsremove.arcs(i=i):
+                    if w.score and bkwd[j].score and b in self.lookup:
+                        out[self.lookup[b]] = 0.0
+            for i in curr:
+                if i in finals and finals[i].score:
+                    out[self.lookup[self.eos]] = 0.0
+                    break
+            return self.make_lazy_weights(out)
         logw_next = await super().logw_next(context)
         return logw_next.spawn(
             new_weights=np.where(
@@ -253,15 +329,9 @@ class BoolFSA(WFSA):
         )
 
     async def batch_logw_next(self, contexts):
-        """
-        Returns next token log weights for a batch of contexts.
-
-        Args:
-            contexts (list): The list of contexts.
-
-        Returns:
-            (list): List of log-weights for next token, one per context.
-        """
+        """Per-token admissibility log-weights for each context."""
+        if self.wfsa.R is Boolean:
+            return [await self.logw_next(c) for c in contexts]
         logw_nexts = await super().batch_logw_next(contexts)
         return [
             logw_next.spawn(

--- a/tests/potential/test_wfsa.py
+++ b/tests/potential/test_wfsa.py
@@ -220,22 +220,22 @@ def test_wfsa_init_wrong_semiring():
 
 
 @pytest.mark.asyncio
-async def test_bool_fsa_from_regex_default_is_log():
-    """Default `from_regex` keeps the Log-semiring internal representation."""
+async def test_bool_fsa_from_regex_default_is_boolean():
+    """Default `from_regex` uses the Boolean semiring."""
     fsa = BoolFSA.from_regex("a(b|c)")
-    assert fsa.wfsa.R is Log
+    assert fsa.wfsa.R is Boolean
     assert (await fsa.complete(b"ab")) == 0
     assert (await fsa.prefix(b"a")) == 0
 
 
 @pytest.mark.asyncio
-async def test_bool_fsa_from_regex_boolean_optin():
-    """Regression: leading-wildcard regex over a large charset; default path
-    silently returns ``-inf``, `semiring="boolean"` gives the right answer."""
+async def test_bool_fsa_from_regex_default_fixes_divergent_scc():
+    """Regression: leading-wildcard regex over a large charset previously
+    silently returned ``-inf`` via the Log path; the Boolean default fixes it."""
     import warnings
 
     pat = r"[\s\S]*[eE]njoy\s+[A-Za-z]+[iI][nN][gG][\s\S]*"
-    fsa = BoolFSA.from_regex(pat, semiring="boolean")
+    fsa = BoolFSA.from_regex(pat)
     assert fsa.wfsa.R is Boolean
     with warnings.catch_warnings():
         warnings.simplefilter("error", category=RuntimeWarning)
@@ -248,10 +248,17 @@ async def test_bool_fsa_from_regex_boolean_optin():
         assert (lw.weights > -float("inf")).any()
 
 
+def test_bool_fsa_from_regex_log_is_deprecated():
+    """Explicit `semiring="log"` still works but emits a DeprecationWarning."""
+    with pytest.warns(DeprecationWarning, match="deprecated"):
+        fsa = BoolFSA.from_regex("a(b|c)", semiring="log")
+    assert fsa.wfsa.R is Log
+
+
 @pytest.mark.asyncio
 async def test_bool_fsa_boolean_consistency():
-    """Math-consistency invariants hold for the Boolean path."""
-    fsa = BoolFSA.from_regex("a(b|c)", semiring="boolean")
+    """Math-consistency invariants hold for the default (Boolean) path."""
+    fsa = BoolFSA.from_regex("a(b|c)")
     assert fsa.wfsa.R is Boolean
     await fsa.assert_logw_next_consistency(b"a")
     await fsa.assert_autoreg_fact(b"a")

--- a/tests/potential/test_wfsa.py
+++ b/tests/potential/test_wfsa.py
@@ -230,8 +230,8 @@ async def test_bool_fsa_from_regex_default_is_log():
 
 @pytest.mark.asyncio
 async def test_bool_fsa_from_regex_boolean_optin():
-    """Regression: leading-wildcard regex hits the Log-semiring precision wall;
-    `semiring="boolean"` avoids it."""
+    """Regression: leading-wildcard regex over a large charset; default path
+    silently returns ``-inf``, `semiring="boolean"` gives the right answer."""
     import warnings
 
     pat = r"[\s\S]*[eE]njoy\s+[A-Za-z]+[iI][nN][gG][\s\S]*"
@@ -260,20 +260,45 @@ async def test_bool_fsa_boolean_consistency():
     await fsa.assert_batch_consistency([b"", b"a", b"ab", b"ac"])
 
 
-@pytest.mark.asyncio
-async def test_bool_fsa_constructed_from_boolean_wfsa():
-    """`BoolFSA(boolean_wfsa)` exercises the Boolean `__init__` branch."""
+@pytest.fixture
+def boolean_wfsa():
+    """A tiny Boolean WFSA: accepts only ``ab``."""
     m = BaseWFSA(Boolean)
     m.add_I(0, Boolean.one)
     m.add_arc(0, b"a"[0], 1, Boolean.one)
     m.add_arc(1, b"b"[0], 2, Boolean.one)
     m.add_F(2, Boolean.one)
-    pot = BoolFSA(m)
+    return m
+
+
+@pytest.mark.asyncio
+async def test_bool_fsa_constructed_from_boolean_wfsa(boolean_wfsa):
+    """`BoolFSA(boolean_wfsa)` exercises the Boolean `__init__` branch and
+    all four boolean public methods on accept / reject / empty-curr paths."""
+    pot = BoolFSA(boolean_wfsa)
     assert pot.wfsa.R is Boolean
+    # accept paths
     assert (await pot.prefix(b"a")) == 0
     assert (await pot.complete(b"ab")) == 0
+    # reject paths
     assert (await pot.complete(b"a")) == -float("inf")
+    # empty-curr paths (no transition from start on 'c')
     assert (await pot.prefix(b"c")) == -float("inf")
+    assert (await pot.complete(b"c")) == -float("inf")
+    with pytest.raises(ValueError, match="zero weight"):
+        await pot.logw_next(b"c")
+
+
+@pytest.mark.asyncio
+async def test_bool_fsa_boolean_batch_logw_next(boolean_wfsa):
+    """``batch_logw_next`` on the Boolean path matches per-context ``logw_next``."""
+    pot = BoolFSA(boolean_wfsa)
+    contexts = [b"", b"a"]
+    single = [(await pot.logw_next(c)).weights for c in contexts]
+    batch = await pot.batch_logw_next(contexts)
+    assert len(batch) == len(contexts)
+    for s, b in zip(single, batch):
+        assert np.array_equal(s, b.weights)
 
 
 def test_bool_fsa_from_regex_bad_semiring_arg():

--- a/tests/potential/test_wfsa.py
+++ b/tests/potential/test_wfsa.py
@@ -211,10 +211,83 @@ async def test_bool_fsa_with_generated_regex(pattern, data):
 
 
 def test_wfsa_init_wrong_semiring():
-    # Test initialization with unsupported semiring
-    wfsa = BaseWFSA(Boolean)  # TODO: support this semiring
+    # Float, Log, and Boolean are accepted; anything else is rejected.
+    from genlm.grammar.semiring import MaxPlus
+
+    wfsa = BaseWFSA(MaxPlus)
     with pytest.raises(ValueError, match="Unsupported semiring"):
         WFSA(wfsa=wfsa)
+
+
+@pytest.mark.asyncio
+async def test_bool_fsa_from_regex_default_is_log():
+    """Default `from_regex` keeps the Log-semiring internal representation."""
+    fsa = BoolFSA.from_regex("a(b|c)")
+    assert fsa.wfsa.R is Log
+    assert (await fsa.complete(b"ab")) == 0
+    assert (await fsa.prefix(b"a")) == 0
+
+
+@pytest.mark.asyncio
+async def test_bool_fsa_from_regex_boolean_optin():
+    """Regression: leading-wildcard regex hits the Log-semiring precision wall;
+    `semiring="boolean"` avoids it."""
+    import warnings
+
+    pat = r"[\s\S]*[eE]njoy\s+[A-Za-z]+[iI][nN][gG][\s\S]*"
+    fsa = BoolFSA.from_regex(pat, semiring="boolean")
+    assert fsa.wfsa.R is Boolean
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", category=RuntimeWarning)
+        assert await fsa.prefix(b"") == 0
+        assert await fsa.prefix(b"Hello") == 0
+        assert await fsa.complete(b"I enjoy walking.") == 0
+        assert await fsa.complete(b"I enjoy films.") == -float("inf")
+        lw = await fsa.logw_next(b"")
+        assert not np.isnan(lw.weights).any()
+        assert (lw.weights > -float("inf")).any()
+
+
+@pytest.mark.asyncio
+async def test_bool_fsa_boolean_consistency():
+    """Math-consistency invariants hold for the Boolean path."""
+    fsa = BoolFSA.from_regex("a(b|c)", semiring="boolean")
+    assert fsa.wfsa.R is Boolean
+    await fsa.assert_logw_next_consistency(b"a")
+    await fsa.assert_autoreg_fact(b"a")
+    await fsa.assert_logw_next_consistency(b"")
+    await fsa.assert_autoreg_fact(b"")
+    await fsa.assert_batch_consistency([b"", b"a", b"ab", b"ac"])
+
+
+@pytest.mark.asyncio
+async def test_bool_fsa_constructed_from_boolean_wfsa():
+    """`BoolFSA(boolean_wfsa)` exercises the Boolean `__init__` branch."""
+    m = BaseWFSA(Boolean)
+    m.add_I(0, Boolean.one)
+    m.add_arc(0, b"a"[0], 1, Boolean.one)
+    m.add_arc(1, b"b"[0], 2, Boolean.one)
+    m.add_F(2, Boolean.one)
+    pot = BoolFSA(m)
+    assert pot.wfsa.R is Boolean
+    assert (await pot.prefix(b"a")) == 0
+    assert (await pot.complete(b"ab")) == 0
+    assert (await pot.complete(b"a")) == -float("inf")
+    assert (await pot.prefix(b"c")) == -float("inf")
+
+
+def test_bool_fsa_from_regex_bad_semiring_arg():
+    with pytest.raises(ValueError, match="semiring must be"):
+        BoolFSA.from_regex("a", semiring="float")
+
+
+def test_wfsa_rejects_boolean():
+    """`WFSA` (weighted) still rejects Boolean; only `BoolFSA` accepts it."""
+    m = BaseWFSA(Boolean)
+    m.add_I(0, Boolean.one)
+    m.add_F(0, Boolean.one)
+    with pytest.raises(ValueError, match="Unsupported semiring"):
+        WFSA(wfsa=m)
 
 
 def test_wfsa_init_float_conversion(log_wfsa):


### PR DESCRIPTION
- `BoolFSA.from_regex()` now constructs the FSA over the Boolean semiring by default
- The `semiring="log"` path is kept for back-compat but emits `DeprecationWarning`
- `BoolFSA(wfsa)` also accepts a Boolean-semiring `WFSA` directly