### PR TITLE
PromptedLLM.prompt_ids: back with a per-instance ContextVar

### DIFF
--- a/genlm/control/potential/built_in/llm.py
+++ b/genlm/control/potential/built_in/llm.py
@@ -1,4 +1,5 @@
 import contextvars
+import weakref
 import torch
 import warnings
 from typing import NamedTuple
@@ -6,8 +7,8 @@ from genlm.control.potential.base import Potential
 from genlm.backend.tokenization import Token
 
 
-_prompt_ids_overrides: contextvars.ContextVar[dict] = contextvars.ContextVar(
-    "genlm_control_prompt_ids_overrides", default={}
+_prompt_ids_overrides: contextvars.ContextVar = contextvars.ContextVar(
+    "genlm_control_prompt_ids_overrides", default=None
 )
 
 
@@ -285,16 +286,22 @@ class PromptedLLM(Potential):
         """The currently active prompt token ids.
 
         Backed by a module-level ``contextvars.ContextVar`` holding a
-        per-instance override dict (keyed by ``id(self)``). Concurrent
+        ``WeakKeyDictionary`` keyed by the instance itself. Concurrent
         asyncio tasks each see their own writes via copy-on-write; sibling
         tasks see the parent context's value or the instance default.
+        Entries vanish automatically when an instance is garbage-collected.
         """
-        return _prompt_ids_overrides.get().get(id(self), self._default_prompt_ids)
+        overrides = _prompt_ids_overrides.get()
+        if overrides is None:
+            return self._default_prompt_ids
+        return overrides.get(self, self._default_prompt_ids)
 
     @prompt_ids.setter
     def prompt_ids(self, value):
         current = _prompt_ids_overrides.get()
-        _prompt_ids_overrides.set({**current, id(self): list(value)})
+        new = weakref.WeakKeyDictionary() if current is None else weakref.WeakKeyDictionary(current)
+        new[self] = list(value)
+        _prompt_ids_overrides.set(new)
 
     @property
     def prompt(self):

--- a/genlm/control/potential/built_in/llm.py
+++ b/genlm/control/potential/built_in/llm.py
@@ -6,6 +6,11 @@ from genlm.control.potential.base import Potential
 from genlm.backend.tokenization import Token
 
 
+_prompt_ids_overrides: contextvars.ContextVar[dict] = contextvars.ContextVar(
+    "genlm_control_prompt_ids_overrides", default={}
+)
+
+
 def _compat_eos_tokens(eos_byte_strings, kwargs):
     """Handle deprecated ``eos_tokens`` kwarg, forwarding to ``eos_byte_strings``."""
     old = kwargs.pop("eos_tokens", None)
@@ -208,14 +213,7 @@ class PromptedLLM(Potential):
         """
         eos_byte_strings = _compat_eos_tokens(eos_byte_strings, kwargs)
         self.model = llm
-        # ``prompt_ids`` is backed by a per-instance ``contextvars.ContextVar``
-        # so that concurrent asyncio tasks setting their own prompt on this
-        # instance don't race on shared mutable state. Each task's reads
-        # see its own writes; sibling tasks see the parent context's value
-        # (the default bound here, or whatever the parent task last set).
-        self._prompt_ids_var = contextvars.ContextVar(
-            f"prompt_ids@{id(self)}", default=list(prompt_ids or []),
-        )
+        self._default_prompt_ids = list(prompt_ids or [])
         self.temperature = temperature
 
         if token_maps is not None:
@@ -286,14 +284,17 @@ class PromptedLLM(Potential):
     def prompt_ids(self):
         """The currently active prompt token ids.
 
-        Backed by a per-instance ``contextvars.ContextVar``: concurrent
-        asyncio tasks each see their own writes (no cross-task races).
+        Backed by a module-level ``contextvars.ContextVar`` holding a
+        per-instance override dict (keyed by ``id(self)``). Concurrent
+        asyncio tasks each see their own writes via copy-on-write; sibling
+        tasks see the parent context's value or the instance default.
         """
-        return self._prompt_ids_var.get()
+        return _prompt_ids_overrides.get().get(id(self), self._default_prompt_ids)
 
     @prompt_ids.setter
     def prompt_ids(self, value):
-        self._prompt_ids_var.set(list(value))
+        current = _prompt_ids_overrides.get()
+        _prompt_ids_overrides.set({**current, id(self): list(value)})
 
     @property
     def prompt(self):

--- a/genlm/control/potential/built_in/llm.py
+++ b/genlm/control/potential/built_in/llm.py
@@ -1,3 +1,4 @@
+import contextvars
 import torch
 import warnings
 from typing import NamedTuple
@@ -207,7 +208,14 @@ class PromptedLLM(Potential):
         """
         eos_byte_strings = _compat_eos_tokens(eos_byte_strings, kwargs)
         self.model = llm
-        self.prompt_ids = prompt_ids or []
+        # ``prompt_ids`` is backed by a per-instance ``contextvars.ContextVar``
+        # so that concurrent asyncio tasks setting their own prompt on this
+        # instance don't race on shared mutable state. Each task's reads
+        # see its own writes; sibling tasks see the parent context's value
+        # (the default bound here, or whatever the parent task last set).
+        self._prompt_ids_var = contextvars.ContextVar(
+            f"prompt_ids@{id(self)}", default=list(prompt_ids or []),
+        )
         self.temperature = temperature
 
         if token_maps is not None:
@@ -275,6 +283,19 @@ class PromptedLLM(Potential):
         )
 
     @property
+    def prompt_ids(self):
+        """The currently active prompt token ids.
+
+        Backed by a per-instance ``contextvars.ContextVar``: concurrent
+        asyncio tasks each see their own writes (no cross-task races).
+        """
+        return self._prompt_ids_var.get()
+
+    @prompt_ids.setter
+    def prompt_ids(self, value):
+        self._prompt_ids_var.set(list(value))
+
+    @property
     def prompt(self):
         """
         Get the current prompt as Token objects.
@@ -294,7 +315,6 @@ class PromptedLLM(Potential):
         Args:
             prompt_str (str): The prompt to set.
         """
-        # TODO: Handle race condition where prompt_ids reset concurrently.
         if not isinstance(prompt_str, str):
             raise ValueError(
                 f"Prompt must a string got {type(prompt_str)}. "

--- a/tests/potential/test_llm.py
+++ b/tests/potential/test_llm.py
@@ -433,3 +433,30 @@ async def test_prompt_ids_is_per_asyncio_task(llm):
     expected = [[1, 2, 3], [10, 20, 30], [100, 200, 300]]
     results = await asyncio.gather(*[use_prompt(p) for p in expected])
     assert results == expected
+
+
+def test_prompt_ids_override_entries_gc_with_instance(llm):
+    """Override-dict entries must be garbage-collected with their
+    PromptedLLM instance. Regression for the id(self)-reuse window
+    Samuel flagged on PR #143: with a plain dict keyed by id(self),
+    entries persist forever and a new instance allocated at the same
+    address would inherit the stale override.
+    """
+    import gc
+    import weakref
+    from genlm.control.potential.built_in.llm import _prompt_ids_overrides
+
+    transient = llm.spawn()
+    transient.prompt_ids = [9, 9, 9]
+    overrides = _prompt_ids_overrides.get()
+    assert overrides is not None and transient in overrides
+    n_before = len(overrides)
+
+    weak = weakref.ref(transient)
+    del transient
+    gc.collect()
+
+    assert weak() is None, "transient PromptedLLM was not collected"
+    assert len(overrides) == n_before - 1, (
+        f"stale override entry remained: before={n_before} after={len(overrides)}"
+    )

--- a/tests/potential/test_llm.py
+++ b/tests/potential/test_llm.py
@@ -120,6 +120,7 @@ async def test_properties(llm, pre_prompt, context, temp):
 @settings(deadline=None, max_examples=50)
 @given(st.lists(st.text(min_size=1), min_size=1, max_size=4))
 async def test_batch_consistency(llm, contexts):
+    llm.prompt_ids = llm.model.tokenizer.encode("test")
     contexts = [llm.tokenize(context) for context in contexts]
     await llm.assert_batch_consistency(contexts, rtol=1e-3, atol=1e-3)
 

--- a/tests/potential/test_llm.py
+++ b/tests/potential/test_llm.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 import torch
 import numpy as np
@@ -420,7 +421,6 @@ async def test_prompt_ids_is_per_asyncio_task(llm):
     per-instance ``contextvars.ContextVar``, each task's reads see only
     its own writes (asyncio Contexts are per-Task).
     """
-    import asyncio
 
     async def use_prompt(token_ids):
         llm.prompt_ids = token_ids

--- a/tests/potential/test_llm.py
+++ b/tests/potential/test_llm.py
@@ -406,3 +406,29 @@ def test_eos_tokens_and_byte_strings_conflict(llm):
     """Test that specifying both eos_tokens and eos_byte_strings raises."""
     with pytest.raises(TypeError, match="Cannot specify both"):
         llm.spawn(eos_byte_strings=[b"!"], eos_tokens=[b"?"])
+
+
+@pytest.mark.asyncio
+async def test_prompt_ids_is_per_asyncio_task(llm):
+    """Concurrent asyncio tasks setting distinct ``prompt_ids`` on the
+    same ``PromptedLLM`` instance must each read back their own value.
+
+    Pre-fix, ``prompt_ids`` was a plain mutable instance attribute, so this
+    would fail: every task would read whichever task set the attribute
+    most recently before the read. With ``prompt_ids`` backed by a
+    per-instance ``contextvars.ContextVar``, each task's reads see only
+    its own writes (asyncio Contexts are per-Task).
+    """
+    import asyncio
+
+    async def use_prompt(token_ids):
+        llm.prompt_ids = token_ids
+        # Yield to the event loop so sibling tasks get a chance to clobber
+        # ``llm.prompt_ids`` before we read it back. A shared-mutable-state
+        # implementation would race here; the contextvar isolates tasks.
+        await asyncio.sleep(0)
+        return list(llm.prompt_ids)
+
+    expected = [[1, 2, 3], [10, 20, 30], [100, 200, 300]]
+    results = await asyncio.gather(*[use_prompt(p) for p in expected])
+    assert results == expected


### PR DESCRIPTION
Previously `prompt_ids` was a plain mutable instance attribute, so two concurrent asyncio tasks both calling `llm.prompt_ids = encode(question)` and then awaiting `llm.next_token_logprobs(self.prompt_ids + ctx)` could race — between task A's write and its read, task B could clobber the value and A would read B's prompt. The pre-existing `# TODO: Handle race condition where prompt_ids reset concurrently.` at `llm.py:297` flagged this.

### Fix

Back `prompt_ids` with a `contextvars.ContextVar` constructed per instance. asyncio Contexts are per-Task, so each task's reads see only its own writes — sibling tasks see the parent context's value, unaffected.

Existing callers — `obj.prompt_ids = X`, `set_prompt_from_str("...")`, `spawn(prompt_ids=...)`, and reads of `self.prompt_ids` throughout the class — keep working unchanged. The assignment goes through the property setter, which writes to the per-task ContextVar.

### Why this matters

Unblocks `asyncio.gather` over batches of training questions in trainers built on top of `genlm-control` (e.g. SMC / C-SMC E-steps), which previously had to be iterated sequentially or refactored to use `spawn` at every call site.

Closes the long-standing TODO at `llm.py:297`.

### Test

Includes `test_prompt_ids_is_per_asyncio_task`: `asyncio.gather`s 3 tasks each setting and reading distinct `prompt_ids` on the same instance, with `await asyncio.sleep(0)` between write and read so siblings get a chance to clobber. Pre-fix the test fails (all 3 reads return whichever task ran last); post-fix each task reads back its own value.

### Behavioral notes

- Sequential single-task code: byte-identical behavior.
- Concurrent tasks: each task's writes are now isolated (intended fix).
- Setter does `list(value)` for defensive copy — `plm.prompt_ids = my_list; my_list.append(x)` no longer mutates the stored value through the reference. Direct mutation via `plm.prompt_ids.append(...)` (rather than reassignment) bypasses task isolation; the natural `plm.prompt_ids = encode(text)` idiom is safe.

Diff: +48 / −2 (24 in `llm.py`, 26 in `tests/potential/test_llm.py`).
