### PR TITLE
Force EOS at max_tokens with importance-weight correction

### DIFF
--- a/genlm/control/sampler/sequence.py
+++ b/genlm/control/sampler/sequence.py
@@ -29,9 +29,14 @@ class SMC:
        particles are resampled according to their weights. This helps focus computation
        on more promising sequences.
 
-    4. Termination: The process continues until either:\n
-        - All sequences reach an end-of-sequence (EOS) token\n
-        - The maximum token length is reached
+    4. Termination: Each sequence terminates either by naturally sampling an
+       end-of-sequence (EOS) token, or by hitting the ``max_tokens`` boundary.
+       In the latter case, EOS is deterministically appended to the sequence
+       and the particle's importance weight is corrected by
+       ``unit_sampler.target.logw_next(context)[EOS]`` (see
+       :meth:`TokenSampler.logw_eos`). This makes the resulting particles
+       properly weighted with respect to the target distribution conditioned
+       on ``|y| <= max_tokens``; every returned sequence ends with EOS.
 
     If a critic is provided, the resulting sequences are properly weighted with respect to the product of the unit sampler's
     target potential and the critic potential (`unit_sampler.target * critic`). If a critic is not provided,
@@ -88,8 +93,10 @@ class SMC:
                 this value, particles are resampled according to their weights. Should be between 0 and 1.
                 Higher values lead to more frequent resampling. Note that when ess_threshold = 0,
                 the critic is only applied at the end of the generation (if it is provided).
-            max_tokens (int): Maximum number of tokens to generate per sequence. Generation
-                may terminate earlier if all sequences reach an EOS token.
+            max_tokens (int): Maximum sequence length (including the terminal EOS token).
+                Sequences that haven't naturally sampled EOS by the boundary have EOS
+                deterministically appended, with an importance-weight correction so the
+                particles target the length-conditioned distribution.
             verbosity (int, optional): Verbosity level for the SMC algorithm. 0 is silent, 1 prints the
                 particles at each step. Default is 0.
             json_path (str, optional): JSON file path for saving a record of the inference run.
@@ -289,14 +296,30 @@ class SequenceModel(Model):
         self.score(start_w)
 
     async def step(self):
-        unit = await self.call(self.unit_sampler)
-        self.token_ctx.append(unit)
+        if self.verbosity > 0:
+            print(self.__repr__())
 
-        inf_weight = self.weight == float("-inf")
-        if inf_weight:
+        # Advance the context: either sample, or force EOS at the max_tokens
+        # boundary. Forcing EOS is equivalent to swapping the proposal for a
+        # point mass at EOS for that step; its IS correction is therefore the
+        # target's unnormalized log-weight on EOS (see TokenSampler.logw_eos).
+        if self.max_tokens == 1:
+            self.score(await self.unit_sampler.logw_eos(self.token_ctx))
+            self.token_ctx.append(EOS)
+        else:
+            unit = await self.call(self.unit_sampler)
+            self.token_ctx.append(unit)
+
+        if self.weight == float("-inf"):
             if self.critic:
                 assert self.twist_amount != float("-inf")
             self.finish()
+            return
+
+        if self.token_ctx[-1] is EOS:
+            self.finish()
+            if self.critic:
+                self.score(await self.critic.score(self.token_ctx))
             return
 
         if self.critic and self.twist_with_critic:
@@ -308,17 +331,7 @@ class SequenceModel(Model):
                 self.finish()
                 return
 
-        if self.verbosity > 0:
-            print(self.__repr__())
-
         self.max_tokens -= 1
-        if self.max_tokens == 0 or self.token_ctx[-1] is EOS:
-            self.finish()
-            if self.critic:
-                if not self.twist_with_critic:
-                    twist_amt = await self.critic.score(self.token_ctx)
-                self.score(twist_amt)
-            return
 
     def __repr__(self):
         return (

--- a/genlm/control/sampler/set.py
+++ b/genlm/control/sampler/set.py
@@ -11,7 +11,7 @@ from genlm.backend.tokenization import Token
 class SetSampler(ABC):
     """Base class for set samplers.
 
-    A set sampler samples a weighted set of tokens from a the vocabulary of a `target` potential.
+    A set sampler samples a weighted set of tokens from the vocabulary of a `target` potential.
 
     Given a context of tokens $x_1, \\ldots, x_{n-1}$ in the target potential's vocabulary and a sampled set of tokens $S \\subseteq \\textsf{target.vocab_eos}$,
     the log-weight associated with each token $x_n$ must correspond to:

--- a/genlm/control/sampler/token.py
+++ b/genlm/control/sampler/token.py
@@ -36,6 +36,16 @@ class TokenSampler(SubModel):
         """Compute the weight of the empty sequence under the target potential."""
         return await self.target.prefix([])
 
+    async def logw_eos(self, context):
+        """
+        Returns teh weight of EOS, used to forse termination in sequence.py.
+        
+        Subclasses may override with cheaper, sampler-specific computations
+        that avoid materializing the full ``logw_next`` vector.
+        """
+        logws = await self.target.logw_next(context)
+        return logws[self.target.eos]
+
     async def forward(self):
         parent = self.parent  # For some reason, need to hold onto this reference.
         token, logw, logp = await self.sample(parent.token_ctx)
@@ -207,6 +217,21 @@ class SetTokenSampler(TokenSampler):
         else:
             token = draw(logps.exp().materialize())
         return token, logws.sum(), logp + logps[token]
+
+    async def logw_eos(self, context):
+        """Boundary EOS log-weight via the ``complete - prefix`` identity.
+
+        Set samplers exist to avoid materializing the full ``target.logw_next``
+        vector; for the EOS entry specifically we get the same value as
+        ``complete(context) - prefix(context)``, which for the typical
+        ``iter_potential * item_potential`` target reduces to a constant
+        number of scalar evaluations on the underlying potentials.
+        """
+        complete_w, prefix_w = await asyncio.gather(
+            self.target.complete(context),
+            self.target.prefix(context),
+        )
+        return complete_w - prefix_w
 
     async def cleanup(self):
         """Clean up the sampler.

--- a/genlm/control/sampler/token.py
+++ b/genlm/control/sampler/token.py
@@ -38,8 +38,8 @@ class TokenSampler(SubModel):
 
     async def logw_eos(self, context):
         """
-        Returns teh weight of EOS, used to forse termination in sequence.py.
-        
+        Returns the weight of EOS, used to force termination in sequence.py.
+
         Subclasses may override with cheaper, sampler-specific computations
         that avoid materializing the full ``logw_next`` vector.
         """
@@ -47,7 +47,7 @@ class TokenSampler(SubModel):
         return logws[self.target.eos]
 
     async def forward(self):
-        parent = self.parent  # For some reason, need to hold onto this reference.
+        parent = self.parent
         token, logw, logp = await self.sample(parent.token_ctx)
         parent.score(logw)
         parent.logp += logp

--- a/genlm/control/sampler/unit.py
+++ b/genlm/control/sampler/unit.py
@@ -91,6 +91,16 @@ class MultiTokenUnitSampler(TokenSampler):
         """Return $\\overrightarrow{\\psi}(\\epsilon)$ (prefix weight of empty sequence)."""
         return await self.subunit_sampler.start_weight()
 
+    async def logw_eos(self, context):
+        """EOS log-weight at the ``max_tokens`` boundary.
+
+        ``context`` is the nested unit context (``[[...], [...], ...]``) that
+        ``SequenceModel`` carries for multi-token units. Flatten it to the token
+        list the underlying target expects, then defer to the subunit sampler so
+        its own (possibly cheaper) ``logw_eos`` is reused.
+        """
+        return await self.subunit_sampler.logw_eos(flatten_units(context))
+
     async def forward(self):
         """Called by LLaMPPL Model.call() to sample one multi-token unit.
 

--- a/tests/sampler/test_seq_sampler.py
+++ b/tests/sampler/test_seq_sampler.py
@@ -182,6 +182,29 @@ async def test_max_tokens_boundary_forces_eos():
 
 
 @pytest.mark.asyncio
+async def test_max_tokens_one_forces_eos():
+    """Edge case max_tokens=1: the first step is already the boundary, so every
+    particle is forced to EOS on the empty context. The only sequence that fits
+    ``|y| <= 1`` is the EOS-only sequence, weighted by the target's mass on the
+    empty completion."""
+    seqs = ["", "a", "ab"]  # "" gives the empty completion positive mass
+    weights = [1.0, 2.0, 3.0]
+    p = WeightedSet(seqs, weights)
+    unit_sampler = DirectTokenSampler(p)
+    sampler = SMC(unit_sampler)
+
+    out = await sampler(n_particles=8, ess_threshold=0, max_tokens=1)
+
+    logeps = await p.prefix([])
+    expected = logeps + (await p.logw_next([]))[p.eos]
+    for seq, logw in out:
+        assert seq == [p.eos]
+        assert np.isclose(logw, expected)
+    # Only the empty completion fits |y| <= 1, so the partition is its weight.
+    assert np.isclose(out.log_ml, np.log(weights[0]))
+
+
+@pytest.mark.asyncio
 async def test_sequence_model_invalid_start_weight():
     class MockPotential(Potential):
         async def prefix(self, context):

--- a/tests/sampler/test_seq_sampler.py
+++ b/tests/sampler/test_seq_sampler.py
@@ -152,14 +152,15 @@ async def test_smc_weights(params):
 
 @pytest.mark.asyncio
 async def test_max_tokens_boundary_forces_eos():
-    """Every returned sequence ends with EOS, and the boundary weight is the
-    target's unnormalized log-weight on EOS at the boundary context."""
-    seqs = ["a", "ab"]  # prefix-overlap: 'a' is both complete and a prefix
-    p = WeightedSet(seqs, [1.0, 2.0])
+    """ We check each particle's importance weight is correct for both
+    termination modes: natural EOS (L < max_tokens) and EOS forced at the
+    boundary (L == max_tokens). """
+    seqs = ["", "a", "ab"]  # "" lets EOS fire at the start; "a" hits the boundary
+    p = WeightedSet(seqs, [1.0, 2.0, 3.0])
     unit_sampler = DirectTokenSampler(p)
     sampler = SMC(unit_sampler)
 
-    out = await sampler(n_particles=8, ess_threshold=0, max_tokens=2)
+    out = await sampler(n_particles=64, ess_threshold=0, max_tokens=2)
     logeps = await p.prefix([])
 
     for seq, logw in out:
@@ -183,10 +184,8 @@ async def test_max_tokens_boundary_forces_eos():
 
 @pytest.mark.asyncio
 async def test_max_tokens_one_forces_eos():
-    """Edge case max_tokens=1: the first step is already the boundary, so every
-    particle is forced to EOS on the empty context. The only sequence that fits
-    ``|y| <= 1`` is the EOS-only sequence, weighted by the target's mass on the
-    empty completion."""
+    """ We check that if we hit the max tokens, the importance weight
+    of the EOS forced particle is correct. """
     seqs = ["", "a", "ab"]  # "" gives the empty completion positive mass
     weights = [1.0, 2.0, 3.0]
     p = WeightedSet(seqs, weights)

--- a/tests/sampler/test_seq_sampler.py
+++ b/tests/sampler/test_seq_sampler.py
@@ -134,9 +134,51 @@ async def test_smc_weights(params):
 
     logeps = await p.prefix([])
     for seq, logw in sequences:
-        logZ = sum([(await p.logw_next(seq[:n])).sum() for n in range(len(seq))])
+        L = len(seq)
+        # Sequences hitting the max_tokens boundary have EOS deterministically
+        # appended, so the final-position IS correction is the unnormalized
+        # target log-weight on EOS (not the partition sum used elsewhere).
+        if L < stop_point:
+            logZ = sum([(await p.logw_next(seq[:n])).sum() for n in range(L)])
+        else:
+            natural = sum(
+                [(await p.logw_next(seq[:n])).sum() for n in range(L - 1)]
+            )
+            boundary = (await p.logw_next(seq[:-1]))[p.eos]
+            logZ = natural + boundary
         twist = await critic.score(seq)
         assert np.isclose(logw, logZ + logeps + twist)
+
+
+@pytest.mark.asyncio
+async def test_max_tokens_boundary_forces_eos():
+    """Every returned sequence ends with EOS, and the boundary weight is the
+    target's unnormalized log-weight on EOS at the boundary context."""
+    seqs = ["a", "ab"]  # prefix-overlap: 'a' is both complete and a prefix
+    p = WeightedSet(seqs, [1.0, 2.0])
+    unit_sampler = DirectTokenSampler(p)
+    sampler = SMC(unit_sampler)
+
+    out = await sampler(n_particles=8, ess_threshold=0, max_tokens=2)
+    logeps = await p.prefix([])
+
+    for seq, logw in out:
+        assert seq[-1] == p.eos
+        L = len(seq)
+        if L < 2:
+            expected = (
+                logeps
+                + sum([(await p.logw_next(seq[:n])).sum() for n in range(L)])
+            )
+        else:
+            expected = (
+                logeps
+                + sum(
+                    [(await p.logw_next(seq[:n])).sum() for n in range(L - 1)]
+                )
+                + (await p.logw_next(seq[:-1]))[p.eos]
+            )
+        assert np.isclose(logw, expected)
 
 
 @pytest.mark.asyncio

--- a/tests/sampler/test_token_sampler.py
+++ b/tests/sampler/test_token_sampler.py
@@ -4,7 +4,12 @@ import tempfile
 import numpy as np
 from arsenal.maths import logsumexp
 
-from genlm.control.sampler import DirectTokenSampler, SetTokenSampler, EagerSetSampler
+from genlm.control.sampler import (
+    DirectTokenSampler,
+    SetTokenSampler,
+    EagerSetSampler,
+    AWRS,
+)
 from conftest import (
     mock_params,
     iter_item_params,
@@ -229,6 +234,51 @@ async def test_set_token_sampler(params):
         have.assert_equal(want, atol=1e-5, rtol=1e-5)
     finally:
         await sampler.cleanup()
+
+
+@pytest.mark.asyncio
+@settings(deadline=None)
+@given(iter_item_params())
+async def test_set_token_sampler_logw_eos(params):
+    """SetTokenSampler.logw_eos uses the ``complete - prefix`` identity to avoid
+    materializing the full ``logw_next`` vector. Check it matches the target's
+    unnormalized log-weight on EOS, which is what SequenceModel scores to force
+    EOS at the max_tokens boundary."""
+    iter_vocab, iter_next_token_ws, item_vocab, item_next_token_ws, context = params
+
+    mock_iter = MockPotential(iter_vocab, np.log(iter_next_token_ws))
+    mock_item = MockPotential(item_vocab, np.log(item_next_token_ws))
+
+    sampler = SetTokenSampler(
+        set_sampler=EagerSetSampler(
+            iter_potential=mock_iter,
+            item_potential=mock_item,
+        )
+    )
+
+    try:
+        got = await sampler.logw_eos(context)
+        want = (await sampler.target.logw_next(context))[sampler.target.eos]
+        assert np.isclose(got, want, atol=1e-5, rtol=1e-5)
+    finally:
+        await sampler.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_awrs_logw_eos():
+    """AWRS inherits the base logw_eos against its ``potential * condition``
+    target. Check it returns that product's unnormalized log-weight on EOS, the
+    quantity SequenceModel scores to force EOS at the max_tokens boundary. The
+    condition allows EOS (0 in log-space) so the boundary weight is finite."""
+    vocab = [bytes([i]) for i in range(3)]
+    potential = MockPotential(vocab, np.log([0.3, 0.3, 0.3, 0.1]))
+    condition = MockPotential(vocab, [0.0, float("-inf"), 0.0, 0.0])  # bans vocab[1]
+    sampler = AWRS(potential, condition, seed=0)
+
+    context = [vocab[0], vocab[2]]
+    got = await sampler.logw_eos(context)
+    want = (await sampler.target.logw_next(context))[sampler.target.eos]
+    assert np.isclose(got, want, atol=1e-5, rtol=1e-5)
 
 
 @pytest.mark.asyncio

--- a/tests/sampler/test_token_sampler.py
+++ b/tests/sampler/test_token_sampler.py
@@ -236,14 +236,13 @@ async def test_set_token_sampler(params):
         await sampler.cleanup()
 
 
+# Unit-level logw_eos checks; end-to-end accumulation is covered in test_seq_sampler.py.
 @pytest.mark.asyncio
 @settings(deadline=None)
 @given(iter_item_params())
 async def test_set_token_sampler_logw_eos(params):
-    """SetTokenSampler.logw_eos uses the ``complete - prefix`` identity to avoid
-    materializing the full ``logw_next`` vector. Check it matches the target's
-    unnormalized log-weight on EOS, which is what SequenceModel scores to force
-    EOS at the max_tokens boundary."""
+    """ We check SetTokenSampler computes the forced-EOS importance weight
+    correctly: its cheap logw_eos(context) equals logw_next(context)[eos]. """
     iter_vocab, iter_next_token_ws, item_vocab, item_next_token_ws, context = params
 
     mock_iter = MockPotential(iter_vocab, np.log(iter_next_token_ws))
@@ -266,10 +265,9 @@ async def test_set_token_sampler_logw_eos(params):
 
 @pytest.mark.asyncio
 async def test_awrs_logw_eos():
-    """AWRS inherits the base logw_eos against its ``potential * condition``
-    target. Check it returns that product's unnormalized log-weight on EOS, the
-    quantity SequenceModel scores to force EOS at the max_tokens boundary. The
-    condition allows EOS (0 in log-space) so the boundary weight is finite."""
+    """ We check AWRS computes the forced-EOS importance weight correctly:
+    logw_eos(context) equals logw_next(context)[eos] of its potential*condition
+    target. """
     vocab = [bytes([i]) for i in range(3)]
     potential = MockPotential(vocab, np.log([0.3, 0.3, 0.3, 0.1]))
     condition = MockPotential(vocab, [0.0, float("-inf"), 0.0, 0.0])  # bans vocab[1]

--- a/tests/sampler/test_token_sampler.py
+++ b/tests/sampler/test_token_sampler.py
@@ -337,18 +337,27 @@ async def test_sis_with_proposal_weights_match_manual_computation(
 
     proposal_logZ = logsumexp(proposal_ws)
 
+    max_tokens = 5
     seqs = await DirectTokenSampler(target, proposal=proposal).smc(
         n_particles=10,
         ess_threshold=0.0,
-        max_tokens=5,
+        max_tokens=max_tokens,
     )
 
     for ctx, actual_logw in zip(seqs.contexts, seqs.log_weights):
         # start_weight = target.prefix([]) = 0 for MockPotential.
+        # Sequences of length == max_tokens had EOS forced at the boundary, so
+        # their final-position IS correction is target.logw_next[EOS] rather
+        # than the natural-sampling formula used at every other position.
         expected_logw = 0.0
-        for tok in ctx:
+        L = len(ctx)
+        boundary_forced = L == max_tokens
+        for i, tok in enumerate(ctx):
             tid = len(vocab) if tok is EOS else target.lookup[tok]
-            expected_logw += target_ws[tid] - proposal_ws[tid] + proposal_logZ
+            if boundary_forced and i == L - 1:
+                expected_logw += target_ws[tid]
+            else:
+                expected_logw += target_ws[tid] - proposal_ws[tid] + proposal_logZ
 
         np.testing.assert_allclose(
             actual_logw, expected_logw, rtol=1e-10,

--- a/tests/sampler/test_unit_sampler.py
+++ b/tests/sampler/test_unit_sampler.py
@@ -264,16 +264,9 @@ async def test_multi_token_unit_sampler_type_error():
 
 @pytest.mark.asyncio
 async def test_multi_token_logw_eos_flattens_nested_context():
-    """Regression for the max_tokens boundary path (sequence.py).
-
-    SequenceModel forces EOS at the boundary via ``unit_sampler.logw_eos(token_ctx)``,
-    and for multi-token units ``token_ctx`` is nested (``[[...], [...], ...]``).
-    ``logw_eos`` must flatten it before consulting the target; otherwise a
-    context-consuming target raises (``WeightedSet`` keys on ``tuple(context)``,
-    so a nested context is an unhashable tuple-of-lists). The override must also
-    return the same value as the target's unnormalized log-weight on EOS at the
-    flattened context.
-    """
+    """ We check MultiTokenUnitSampler computes the forced-EOS importance weight
+    correctly: logw_eos flattens its nested context and returns
+    logw_next(flattened)[eos]. """
     p = WeightedSet(["ab", "a"], [1.0, 2.0])
     unit_sampler = MultiTokenUnitSampler(
         subunit_sampler=DirectTokenSampler(p),

--- a/tests/sampler/test_unit_sampler.py
+++ b/tests/sampler/test_unit_sampler.py
@@ -13,7 +13,7 @@ from genlm.control.sampler.unit import flatten_units
 from genlm.control.sampler import CFGBoundary
 from genlm.control.sampler.sequence import SMC
 from genlm.control.constant import EOS
-from conftest import MockPotential
+from conftest import MockPotential, WeightedSet
 
 
 @pytest.mark.asyncio
@@ -260,6 +260,30 @@ async def test_multi_token_unit_sampler_type_error():
             subunit_sampler="not a sampler",
             boundary_predicate=TokenSetBoundary({b" "}),
         )
+
+
+@pytest.mark.asyncio
+async def test_multi_token_logw_eos_flattens_nested_context():
+    """Regression for the max_tokens boundary path (sequence.py).
+
+    SequenceModel forces EOS at the boundary via ``unit_sampler.logw_eos(token_ctx)``,
+    and for multi-token units ``token_ctx`` is nested (``[[...], [...], ...]``).
+    ``logw_eos`` must flatten it before consulting the target; otherwise a
+    context-consuming target raises (``WeightedSet`` keys on ``tuple(context)``,
+    so a nested context is an unhashable tuple-of-lists). The override must also
+    return the same value as the target's unnormalized log-weight on EOS at the
+    flattened context.
+    """
+    p = WeightedSet(["ab", "a"], [1.0, 2.0])
+    unit_sampler = MultiTokenUnitSampler(
+        subunit_sampler=DirectTokenSampler(p),
+        boundary_predicate=FixedLengthBoundary(1),
+        max_subunits_per_unit=10,
+    )
+    nested = [["a"], ["b"]]  # token_ctx after two single-token units
+    got = await unit_sampler.logw_eos(nested)
+    want = (await p.logw_next(["a", "b"]))[p.eos]
+    assert np.isclose(got, want)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
SequenceModel previously truncated sequences without an EOS token when hitting max_tokens, producing samples that did not target the length-conditioned distribution. At the boundary step we now swap the proposal for a point mass on EOS and apply the corresponding IS correction via a new TokenSampler.logw_eos method, so particles are properly weighted with respect to the target conditioned on |y| <= max_tokens; every returned sequence ends with EOS.

SetTokenSampler overrides logw_eos to use complete(ctx) - prefix(ctx), avoiding materializing the full logw_next vector that set samplers are designed to skip during regular sampling.

Tests updated to reflect the new boundary semantics and a focused prefix-overlap test added to cover a case the existing property test was not exercising.