### PR TITLE
Add Surprise & Critic boundaries and better documentation to MultiTokenUnitSampler

### DIFF
--- a/docs/samplers.md
+++ b/docs/samplers.md
@@ -113,6 +113,48 @@ topk_sampler = topk_token_sampler(llm, fsa, K=10)
 eager_sampler = eager_token_sampler(llm, fsa)
 ```
 
+## Unit Sampling
+
+The samplers above generate one token at a time. A [`MultiTokenUnitSampler`][genlm.control.sampler.unit.MultiTokenUnitSampler] instead generates at a *unit* consisting of one or more tokens by repeatedly drawing tokens from an inner `subunit_sampler` (any `TokenSampler`) until a [`BoundaryPredicate`][genlm.control.sampler.unit.BoundaryPredicate] signals that the unit is complete. Typical units are words, lines, or grammar terminals.
+
+Because it is itself a `TokenSampler`, it plugs into the same SMC loop as the samplers above. Its `context` and the units it returns are *nested* lists of tokens; use [`flatten_units`][genlm.control.sampler.unit.flatten_units] when feeding them to a potential.
+
+```python
+from genlm.control.sampler import (
+    direct_token_sampler, MultiTokenUnitSampler, TokenSetBoundary,
+)
+
+# Inner per-token sampler, plus a rule for where units end.
+subunit_sampler = direct_token_sampler(llm)
+boundary = TokenSetBoundary({b" ", b"\n"})  # a unit ends at whitespace or newline
+
+unit_sampler = MultiTokenUnitSampler(subunit_sampler, boundary)
+unit, logw, _ = await unit_sampler.sample(context)  # e.g. unit == [b"hello", b" "]
+```
+
+A unit's weight is the product of its tokens' weights, so sampling stays properly weighted with respect to the target potential.
+
+### Boundary predicates
+
+A boundary predicate decides when the accumulated tokens form a complete unit. The built-in predicates are:
+
+| Predicate | A unit ends when… |
+|-----------|-------------------|
+| [`TokenSetBoundary`][genlm.control.sampler.unit.TokenSetBoundary] | the last token is in a given set (e.g. whitespace) |
+| [`FixedLengthBoundary`][genlm.control.sampler.unit.FixedLengthBoundary] | a fixed number of tokens is reached |
+| [`CFGBoundary`][genlm.control.sampler.unit.CFGBoundary] | the tokens parse as a complete unit of a Lark grammar |
+| [`SurpriseBoundary`][genlm.control.sampler.unit.SurpriseBoundary] | the unit's accumulated log-weight crosses a threshold |
+
+### Custom boundary predicates
+
+Subclass [`BoundaryPredicate`][genlm.control.sampler.unit.BoundaryPredicate] and implement `__call__`, returning `True` once the buffer forms a complete unit.
+
+```python
+class EndsWithPeriod(BoundaryPredicate):
+    def __call__(self, unit_context, subunit_buffer, **kwargs):
+        return subunit_buffer[-1] == b"."
+```
+
 ## Sampler Selection Guide for Controlled Generation
 
 The following table provides general guidelines for selecting a sampler in the context of controlled generation from an LLM. Note that the best sampler may vary depending on the specific controlled generation task.

--- a/genlm/control/sampler/__init__.py
+++ b/genlm/control/sampler/__init__.py
@@ -7,6 +7,8 @@ from .unit import (
     TokenSetBoundary,
     FixedLengthBoundary,
     CFGBoundary,
+    SurpriseBoundary,
+    CriticBoundary,
     flatten_units,
 )
 from genlm.control.potential import Potential
@@ -83,5 +85,7 @@ __all__ = [
     "TokenSetBoundary",
     "FixedLengthBoundary",
     "CFGBoundary",
+    "SurpriseBoundary",
+    "CriticBoundary",
     "flatten_units",
 ]

--- a/genlm/control/sampler/unit.py
+++ b/genlm/control/sampler/unit.py
@@ -262,14 +262,13 @@ class BoundaryPredicate(ABC):
     def __call__(self, unit_context: list, subunit_buffer: list, **kwargs) -> bool:
         """Check if subunit buffer forms a complete unit.
 
+        `MultiTokenUnitSampler` passes the current unit's running log-weight
+        $\\sum_i \\log w_i$ as a ``cumulative_logw`` keyword; predicates that don't
+        need it should absorb it (and any future signals) via ``**kwargs``.
+
         Args:
             unit_context (list): Sequence of completed units $\\bm{x} \\in \\mathcal{A}^*$
             subunit_buffer (list): Current sequence of subunits $\\bm{s} \\in \\mathcal{B}^*$
-            **kwargs: Extra signals supplied by `MultiTokenUnitSampler`. Currently
-                includes ``cumulative_logw`` (float): the running log-weight
-                $\\sum_i \\log w_i$ accumulated over the subunits sampled so far for
-                the *current* unit. Predicates that don't need it should ignore it
-                via ``**kwargs``.
 
         Returns:
             bool: True if $\\bm{s}$ forms a complete unit $x \\in \\mathcal{A}$. May also
@@ -589,12 +588,14 @@ class CriticBoundary(_ThresholdBoundary):
     resampling. Fires when ``delta`` crosses ``threshold`` per ``sign``; a critic
     returning ``-inf`` (dead particle) fires under ``"abs"``/``"down"``.
 
-    ``__call__`` is ``async`` and requires the sampler's await support.
+    ``__call__`` is ``async`` and requires the sampler's await support. The
+    ``threshold``, ``min_subunits``, ``max_subunits``, and ``sign`` arguments behave
+    as in `SurpriseBoundary`.
 
     Args:
-        critic: a `Potential` whose ``prefix(context)`` returns a float log-weight.
-            Called once per subunit, so it must be safe to evaluate mid-stream.
-        threshold, min_subunits, max_subunits, sign: as in `SurpriseBoundary`.
+        critic (Potential): a potential whose ``prefix(context)`` returns a float
+            log-weight. Called once per subunit, so it must be safe to evaluate
+            mid-stream.
         coalesce_grammar (bool): if True, add the subunit-side ``cumulative_logw`` to
             the critic delta before thresholding. Default False (critic delta only).
     """

--- a/genlm/control/sampler/unit.py
+++ b/genlm/control/sampler/unit.py
@@ -1,3 +1,4 @@
+import inspect
 from abc import ABC, abstractmethod
 from typing import Any, Iterable, Optional
 
@@ -5,6 +6,29 @@ from genlm.control.constant import EOS
 from genlm.control.sampler.token import TokenSampler
 from lark import Lark
 from lark.exceptions import LarkError
+
+
+def _predicate_accepts_cumulative_logw(predicate) -> bool:
+    """Whether ``predicate.__call__`` can receive a ``cumulative_logw`` keyword.
+
+    True if it declares ``**kwargs`` or a ``cumulative_logw`` parameter. Predicates
+    using the original ``(unit_context, subunit_buffer)`` signature return False, so
+    the sampler falls back to the two-argument call (backward compatible).
+    """
+    try:
+        sig = inspect.signature(predicate.__call__)
+    except (TypeError, ValueError):  # pragma: no cover - C/builtin callables
+        # Can't introspect (e.g. a builtin). Be conservative and don't pass it.
+        return False
+    for param in sig.parameters.values():
+        if param.kind is inspect.Parameter.VAR_KEYWORD:
+            return True
+        if param.name == "cumulative_logw" and param.kind in (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        ):
+            return True
+    return False
 
 
 def flatten_units(context):
@@ -47,6 +71,12 @@ class MultiTokenUnitSampler(TokenSampler):
     $w_1, w_2, \\ldots, w_n$, the unit weight is $w = \\prod_{i=1}^{n} w_i$ (or
     $\\log w = \\sum_{i=1}^{n} \\log w_i$ in log-space).
 
+    **Weight- and critic-aware boundaries**: the predicate receives the running unit
+    log-weight via a ``cumulative_logw`` keyword, so boundaries can react to the
+    incremental importance weights (see `WeightGuidedBoundary`, `SurpriseBoundary`).
+    Predicates may also be ``async`` to ``await`` a critic potential mid-unit. Both are
+    opt-in; the original ``(unit_context, subunit_buffer)`` signature keeps working.
+
     Args:
         subunit_sampler (TokenSampler): Sampler for subunits $s \\in \\mathcal{B}$
         boundary_predicate (BoundaryPredicate): Determines when a sequence of tokens forms
@@ -86,6 +116,12 @@ class MultiTokenUnitSampler(TokenSampler):
         self.subunit_sampler = subunit_sampler
         self.boundary_predicate = boundary_predicate
         self.max_subunits_per_unit = max_subunits_per_unit
+
+        # Whether to forward the running unit log-weight to the predicate. Cached
+        # here so we don't re-introspect the signature on every subunit.
+        self._boundary_accepts_cumulative_logw = _predicate_accepts_cumulative_logw(
+            boundary_predicate
+        )
 
     async def start_weight(self):
         """Return $\\overrightarrow{\\psi}(\\epsilon)$ (prefix weight of empty sequence)."""
@@ -178,7 +214,19 @@ class MultiTokenUnitSampler(TokenSampler):
                 return subunit_buffer, cumulative_logw, cumulative_logp
 
             # Check boundary: is $\\bm{s} \\in \\mathcal{A}$ (complete unit)?
-            if self.boundary_predicate(unit_context, subunit_buffer):
+            # Opt-in predicates also receive the running unit log-weight; async
+            # predicates (e.g. ones that query a critic) return a coroutine we await.
+            if self._boundary_accepts_cumulative_logw:
+                is_boundary = self.boundary_predicate(
+                    unit_context, subunit_buffer, cumulative_logw=cumulative_logw
+                )
+            else:
+                is_boundary = self.boundary_predicate(unit_context, subunit_buffer)
+
+            if inspect.iscoroutine(is_boundary):
+                is_boundary = await is_boundary
+
+            if is_boundary:
                 # Let the predicate finalize the unit (e.g., remove delimiter tokens)
                 unit = self.boundary_predicate.finalize_unit(subunit_buffer)
                 return unit, cumulative_logw, cumulative_logp
@@ -197,8 +245,14 @@ class BoundaryPredicate(ABC):
     A boundary predicate determines when a sequence of subunits $\\bm{s} \\in \\mathcal{B}^*$
     forms a complete unit $x \\in \\mathcal{A}$.
 
-    `__call__` method receives unit context and subunit buffer, allowing predicates
-    to be stateless and context-aware.
+    `__call__` receives unit context and subunit buffer plus keyword signals from the
+    sampler (currently ``cumulative_logw``); subclasses should accept ``**kwargs`` to
+    stay forward-compatible. The original two-argument signature still works — the
+    sampler detects it and omits the extra keyword.
+
+    `__call__` may be sync (returning ``bool``) or ``async`` (returning an awaitable
+    ``bool``); `MultiTokenUnitSampler` awaits coroutine results, so a predicate can
+    ``await`` a critic potential mid-unit before deciding.
 
     `finalize_unit` method transforms the buffer into the final unit after boundary
     detection, allowing predicates to control what tokens are included (e.g., removing
@@ -206,15 +260,21 @@ class BoundaryPredicate(ABC):
     """
 
     @abstractmethod
-    def __call__(self, unit_context: list, subunit_buffer: list) -> bool:
+    def __call__(self, unit_context: list, subunit_buffer: list, **kwargs) -> bool:
         """Check if subunit buffer forms a complete unit.
 
         Args:
             unit_context (list): Sequence of completed units $\\bm{x} \\in \\mathcal{A}^*$
             subunit_buffer (list): Current sequence of subunits $\\bm{s} \\in \\mathcal{B}^*$
+            **kwargs: Extra signals supplied by `MultiTokenUnitSampler`. Currently
+                includes ``cumulative_logw`` (float): the running log-weight
+                $\\sum_i \\log w_i$ accumulated over the subunits sampled so far for
+                the *current* unit. Predicates that don't need it should ignore it
+                via ``**kwargs``.
 
         Returns:
-            bool: True if $\\bm{s}$ forms a complete unit $x \\in \\mathcal{A}$
+            bool: True if $\\bm{s}$ forms a complete unit $x \\in \\mathcal{A}$. May also
+                return an awaitable resolving to ``bool`` (see class docstring).
         """
         pass  # pragma: no cover
 
@@ -253,7 +313,7 @@ class TokenSetBoundary(BoundaryPredicate):
     def __init__(self, boundary_tokens: Iterable):
         self.boundary_tokens = set(boundary_tokens)
 
-    def __call__(self, unit_context: list, subunit_buffer: list) -> bool:
+    def __call__(self, unit_context: list, subunit_buffer: list, **kwargs) -> bool:
         """Check boundary (ignore unit_context for stateless predicate)."""
         return bool(subunit_buffer and subunit_buffer[-1] in self.boundary_tokens)
 
@@ -279,7 +339,7 @@ class FixedLengthBoundary(BoundaryPredicate):
             raise ValueError(f"Length must be positive, got {length}")
         self.length = length
 
-    def __call__(self, unit_context: list, subunit_buffer: list) -> bool:
+    def __call__(self, unit_context: list, subunit_buffer: list, **kwargs) -> bool:
         """Check boundary (ignores unit_context for stateless predicate)."""
         return len(subunit_buffer) >= self.length
 
@@ -352,7 +412,7 @@ class CFGBoundary(BoundaryPredicate):
         except Exception as e:
             raise ValueError(f"Failed to create Lark parser: {e}") from e
 
-    def __call__(self, unit_context: list, subunit_buffer: list) -> bool:
+    def __call__(self, unit_context: list, subunit_buffer: list, **kwargs) -> bool:
         """Check if buffer forms a complete syntactic unit.
 
         Args:
@@ -416,3 +476,178 @@ class CFGBoundary(BoundaryPredicate):
             f", complete_rules={self.complete_rules}" if self.complete_rules else ""
         )
         return f"CFGBoundary(start={self.start_rule!r}{rules_str})"
+
+
+def _validate_boundary_params(threshold, min_subunits, max_subunits, sign):
+    """Shared argument validation for the weight/critic boundary predicates."""
+    if sign not in ("abs", "down", "up"):
+        raise ValueError(f"sign must be 'abs', 'down', or 'up', got {sign!r}")
+    if threshold <= 0:
+        raise ValueError(f"threshold must be positive, got {threshold}")
+    if min_subunits < 1:
+        raise ValueError(f"min_subunits must be >= 1, got {min_subunits}")
+    if max_subunits < min_subunits:
+        raise ValueError(
+            f"max_subunits ({max_subunits}) must be >= min_subunits ({min_subunits})"
+        )
+
+
+def _length_gate(n_subunits, min_subunits, max_subunits):
+    """Resolve a boundary from length alone: True (force), False (too short), or
+    None (defer to the weight/critic signal)."""
+    if n_subunits >= max_subunits:
+        return True
+    if n_subunits < min_subunits:
+        return False
+    return None
+
+
+def _crosses_threshold(value, threshold, sign):
+    """Whether ``value`` crosses ``threshold`` in the given direction. NaN never does."""
+    if not isinstance(value, (int, float)) or value != value:  # type / NaN guard
+        return False
+    if sign == "abs":
+        return abs(value) >= threshold
+    if sign == "down":
+        return value <= -threshold
+    return value >= threshold  # sign == "up"
+
+
+class SurpriseBoundary(BoundaryPredicate):
+    """Boundary placed when the unit's accumulated log-weight crosses a threshold.
+
+    Reacts to the incremental importance weights (``cumulative_logw``) rather than the
+    surface tokens: a large deviation means the target potential is informative about
+    the current tokens, so a boundary here lets downstream SMC resample where the
+    weight signal is strongest. Domain-agnostic and requires no pilot run.
+
+    The ``sign`` controls which direction counts, which matters when the weight is
+    one-sided: grammar-only weights are bounded above by 0, so ``sign="down"`` fires
+    only on accumulated penalties and ignores positive noise.
+
+    Args:
+        threshold (float): Log-weight magnitude that fires a boundary. Default 1.5. > 0.
+        min_subunits (int): Minimum subunits before firing. Default 1.
+        max_subunits (int): Force a boundary after this many subunits. Default 50.
+        sign (str): ``"abs"`` (default) fires on ``|cumulative_logw| >= threshold``,
+            ``"down"`` on ``cumulative_logw <= -threshold``, ``"up"`` on
+            ``cumulative_logw >= +threshold``.
+
+    Example:
+        >>> boundary = SurpriseBoundary(threshold=1.0, sign="down", min_subunits=2)
+        >>> boundary([], [b"a", b"b"], cumulative_logw=2.0)   # wrong direction
+        False
+        >>> boundary([], [b"a", b"b"], cumulative_logw=-1.2)  # penalty crossed
+        True
+    """
+
+    def __init__(self, threshold=1.5, min_subunits=1, max_subunits=50, sign="abs"):
+        _validate_boundary_params(threshold, min_subunits, max_subunits, sign)
+        self.threshold = threshold
+        self.min_subunits = min_subunits
+        self.max_subunits = max_subunits
+        self.sign = sign
+
+    def __call__(self, unit_context, subunit_buffer, **kwargs):
+        gate = _length_gate(len(subunit_buffer), self.min_subunits, self.max_subunits)
+        if gate is not None:
+            return gate
+        cw = kwargs.get("cumulative_logw", 0.0)
+        return _crosses_threshold(cw, self.threshold, self.sign)
+
+    def __repr__(self):
+        return (
+            f"SurpriseBoundary(threshold={self.threshold}, sign={self.sign!r}, "
+            f"min_subunits={self.min_subunits}, max_subunits={self.max_subunits})"
+        )
+
+
+class CriticBoundary(BoundaryPredicate):
+    """Async boundary placed on a critic potential's per-unit log-weight change.
+
+    Reacts to an expensive ``critic`` rather than the surface tokens or the cheap
+    subunit weight. At each subunit it measures how much the critic's prefix score has
+    moved over the *current* (in-progress) unit::
+
+        delta = critic.prefix(ctx + buffer) - critic.prefix(ctx)
+
+    where ``ctx`` is the flattened completed `unit_context`. The baseline is derived
+    from ``unit_context`` (cached per unit), so the predicate is stateless across SMC
+    resampling. Fires when ``delta`` crosses ``threshold`` per ``sign``; a critic
+    returning ``-inf`` (dead particle) fires under ``"abs"``/``"down"``.
+
+    ``__call__`` is ``async`` and requires the sampler's await support.
+
+    Args:
+        critic: a `Potential` whose ``prefix(context)`` returns a float log-weight.
+            Called once per subunit, so it must be safe to evaluate mid-stream.
+        threshold, min_subunits, max_subunits, sign: as in `SurpriseBoundary`.
+        coalesce_grammar (bool): if True, add the subunit-side ``cumulative_logw`` to
+            the critic delta before thresholding. Default False (critic delta only).
+    """
+
+    def __init__(
+        self,
+        critic,
+        threshold=1.5,
+        min_subunits=1,
+        max_subunits=50,
+        sign="abs",
+        coalesce_grammar=False,
+    ):
+        _validate_boundary_params(threshold, min_subunits, max_subunits, sign)
+        self.critic = critic
+        self.threshold = threshold
+        self.min_subunits = min_subunits
+        self.max_subunits = max_subunits
+        self.sign = sign
+        self.coalesce_grammar = coalesce_grammar
+        # Per-unit baseline critic value, keyed by a hash of the completed context.
+        # Cleared by reset(); grows with the number of distinct contexts seen.
+        self._baseline_cache = {}
+
+    @staticmethod
+    def _critic_context(tokens):
+        """Flatten units and drop EOS for feeding the critic's ``prefix``."""
+        return [t for t in flatten_units(tokens) if t is not EOS]
+
+    def reset(self):
+        """Clear cached baselines. Call between independent generations."""
+        self._baseline_cache.clear()
+
+    async def _baseline(self, flat_ctx):
+        try:
+            key = hash(tuple(flat_ctx))
+        except TypeError:  # pragma: no cover - non-hashable tokens
+            key = hash(tuple(repr(t) for t in flat_ctx))
+        if key not in self._baseline_cache:
+            self._baseline_cache[key] = float(await self.critic.prefix(flat_ctx))
+        return self._baseline_cache[key]
+
+    async def __call__(self, unit_context, subunit_buffer, **kwargs):
+        gate = _length_gate(len(subunit_buffer), self.min_subunits, self.max_subunits)
+        if gate is not None:
+            return gate
+
+        baseline_ctx = self._critic_context(unit_context)
+        current_ctx = baseline_ctx + [t for t in subunit_buffer if t is not EOS]
+        try:
+            base = await self._baseline(baseline_ctx)
+            delta = float(await self.critic.prefix(current_ctx)) - base
+        except Exception:
+            # Critic failure: don't fire, don't poison the baseline cache.
+            return False
+
+        if self.coalesce_grammar:
+            cw = kwargs.get("cumulative_logw", 0.0)
+            if isinstance(cw, (int, float)) and cw == cw:  # ignore NaN/non-numeric
+                delta += cw
+
+        return _crosses_threshold(delta, self.threshold, self.sign)
+
+    def __repr__(self):
+        return (
+            f"CriticBoundary(threshold={self.threshold}, sign={self.sign!r}, "
+            f"coalesce_grammar={self.coalesce_grammar}, "
+            f"min_subunits={self.min_subunits}, max_subunits={self.max_subunits})"
+        )

--- a/genlm/control/sampler/unit.py
+++ b/genlm/control/sampler/unit.py
@@ -8,29 +8,6 @@ from lark import Lark
 from lark.exceptions import LarkError
 
 
-def _predicate_accepts_cumulative_logw(predicate) -> bool:
-    """Whether ``predicate.__call__`` can receive a ``cumulative_logw`` keyword.
-
-    True if it declares ``**kwargs`` or a ``cumulative_logw`` parameter. Predicates
-    using the original ``(unit_context, subunit_buffer)`` signature return False, so
-    the sampler falls back to the two-argument call (backward compatible).
-    """
-    try:
-        sig = inspect.signature(predicate.__call__)
-    except (TypeError, ValueError):  # pragma: no cover - C/builtin callables
-        # Can't introspect (e.g. a builtin). Be conservative and don't pass it.
-        return False
-    for param in sig.parameters.values():
-        if param.kind is inspect.Parameter.VAR_KEYWORD:
-            return True
-        if param.name == "cumulative_logw" and param.kind in (
-            inspect.Parameter.POSITIONAL_OR_KEYWORD,
-            inspect.Parameter.KEYWORD_ONLY,
-        ):
-            return True
-    return False
-
-
 def flatten_units(context):
     """
     Flatten nested unit context to a flat token list. When using MultiTokenUnitSampler, token_ctx becomes nested [[...], [...], ...].
@@ -73,8 +50,8 @@ class MultiTokenUnitSampler(TokenSampler):
 
     **Weight- and critic-aware boundaries**: the predicate receives the running unit
     log-weight via a ``cumulative_logw`` keyword, so boundaries can react to the
-    incremental importance weights (see `WeightGuidedBoundary`, `SurpriseBoundary`).
-    Predicates may also be ``async`` to ``await`` a critic potential mid-unit. Both are
+    incremental importance weights (see `SurpriseBoundary`). Predicates may also be
+    ``async`` to ``await`` a critic potential mid-unit (see `CriticBoundary`). Both are
     opt-in; the original ``(unit_context, subunit_buffer)`` signature keeps working.
 
     Args:
@@ -119,9 +96,31 @@ class MultiTokenUnitSampler(TokenSampler):
 
         # Whether to forward the running unit log-weight to the predicate. Cached
         # here so we don't re-introspect the signature on every subunit.
-        self._boundary_accepts_cumulative_logw = _predicate_accepts_cumulative_logw(
-            boundary_predicate
+        self._boundary_accepts_cumulative_logw = (
+            self._predicate_accepts_cumulative_logw(boundary_predicate)
         )
+
+    @staticmethod
+    def _predicate_accepts_cumulative_logw(predicate) -> bool:
+        """Whether ``predicate.__call__`` can receive a ``cumulative_logw`` keyword.
+
+        True if it declares ``**kwargs`` or a ``cumulative_logw`` parameter. Predicates
+        using the original ``(unit_context, subunit_buffer)`` signature return False, so
+        the sampler falls back to the two-argument call (backward compatible).
+        """
+        try:
+            sig = inspect.signature(predicate.__call__)
+        except (TypeError, ValueError):  # pragma: no cover - C/builtin callables
+            return False  # can't introspect; be conservative and don't pass it
+        for param in sig.parameters.values():
+            if param.kind is inspect.Parameter.VAR_KEYWORD:
+                return True
+            if param.name == "cumulative_logw" and param.kind in (
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.KEYWORD_ONLY,
+            ):
+                return True
+        return False
 
     async def start_weight(self):
         """Return $\\overrightarrow{\\psi}(\\epsilon)$ (prefix weight of empty sequence)."""
@@ -478,42 +477,61 @@ class CFGBoundary(BoundaryPredicate):
         return f"CFGBoundary(start={self.start_rule!r}{rules_str})"
 
 
-def _validate_boundary_params(threshold, min_subunits, max_subunits, sign):
-    """Shared argument validation for the weight/critic boundary predicates."""
-    if sign not in ("abs", "down", "up"):
-        raise ValueError(f"sign must be 'abs', 'down', or 'up', got {sign!r}")
-    if threshold <= 0:
-        raise ValueError(f"threshold must be positive, got {threshold}")
-    if min_subunits < 1:
-        raise ValueError(f"min_subunits must be >= 1, got {min_subunits}")
-    if max_subunits < min_subunits:
-        raise ValueError(
-            f"max_subunits ({max_subunits}) must be >= min_subunits ({min_subunits})"
-        )
+class _ThresholdBoundary(BoundaryPredicate):
+    """Base for boundaries that fire when a scalar signal crosses a threshold.
+
+    Concrete subclasses implement `__call__` and obtain their signal differently
+    (the cheap ``cumulative_logw``, or an expensive critic delta), but share the
+    argument validation, the length-based gating (`_gate`), and the signed
+    threshold test (`_crosses`).
+
+    Args:
+        threshold (float): Signal magnitude that fires a boundary. Must be > 0.
+        min_subunits (int): Minimum subunits before firing.
+        max_subunits (int): Force a boundary after this many subunits.
+        sign (str): ``"abs"`` fires on ``|signal| >= threshold``, ``"down"`` on
+            ``signal <= -threshold``, ``"up"`` on ``signal >= +threshold``.
+    """
+
+    def __init__(self, threshold, min_subunits, max_subunits, sign):
+        if sign not in ("abs", "down", "up"):
+            raise ValueError(f"sign must be 'abs', 'down', or 'up', got {sign!r}")
+        if threshold <= 0:
+            raise ValueError(f"threshold must be positive, got {threshold}")
+        if min_subunits < 1:
+            raise ValueError(f"min_subunits must be >= 1, got {min_subunits}")
+        if max_subunits < min_subunits:
+            raise ValueError(
+                f"max_subunits ({max_subunits}) must be >= min_subunits "
+                f"({min_subunits})"
+            )
+        self.threshold = threshold
+        self.min_subunits = min_subunits
+        self.max_subunits = max_subunits
+        self.sign = sign
+
+    def _gate(self, n_subunits):
+        """Decide from length alone: True (force), False (too short), or None
+        (defer to the signal)."""
+        if n_subunits >= self.max_subunits:
+            return True
+        if n_subunits < self.min_subunits:
+            return False
+        return None
+
+    def _crosses(self, value):
+        """Whether ``value`` crosses the threshold in ``sign``'s direction. NaN and
+        non-numeric values never cross."""
+        if not isinstance(value, (int, float)) or value != value:
+            return False
+        if self.sign == "abs":
+            return abs(value) >= self.threshold
+        if self.sign == "down":
+            return value <= -self.threshold
+        return value >= self.threshold  # sign == "up"
 
 
-def _length_gate(n_subunits, min_subunits, max_subunits):
-    """Resolve a boundary from length alone: True (force), False (too short), or
-    None (defer to the weight/critic signal)."""
-    if n_subunits >= max_subunits:
-        return True
-    if n_subunits < min_subunits:
-        return False
-    return None
-
-
-def _crosses_threshold(value, threshold, sign):
-    """Whether ``value`` crosses ``threshold`` in the given direction. NaN never does."""
-    if not isinstance(value, (int, float)) or value != value:  # type / NaN guard
-        return False
-    if sign == "abs":
-        return abs(value) >= threshold
-    if sign == "down":
-        return value <= -threshold
-    return value >= threshold  # sign == "up"
-
-
-class SurpriseBoundary(BoundaryPredicate):
+class SurpriseBoundary(_ThresholdBoundary):
     """Boundary placed when the unit's accumulated log-weight crosses a threshold.
 
     Reacts to the incremental importance weights (``cumulative_logw``) rather than the
@@ -542,18 +560,13 @@ class SurpriseBoundary(BoundaryPredicate):
     """
 
     def __init__(self, threshold=1.5, min_subunits=1, max_subunits=50, sign="abs"):
-        _validate_boundary_params(threshold, min_subunits, max_subunits, sign)
-        self.threshold = threshold
-        self.min_subunits = min_subunits
-        self.max_subunits = max_subunits
-        self.sign = sign
+        super().__init__(threshold, min_subunits, max_subunits, sign)
 
     def __call__(self, unit_context, subunit_buffer, **kwargs):
-        gate = _length_gate(len(subunit_buffer), self.min_subunits, self.max_subunits)
+        gate = self._gate(len(subunit_buffer))
         if gate is not None:
             return gate
-        cw = kwargs.get("cumulative_logw", 0.0)
-        return _crosses_threshold(cw, self.threshold, self.sign)
+        return self._crosses(kwargs.get("cumulative_logw", 0.0))
 
     def __repr__(self):
         return (
@@ -562,7 +575,7 @@ class SurpriseBoundary(BoundaryPredicate):
         )
 
 
-class CriticBoundary(BoundaryPredicate):
+class CriticBoundary(_ThresholdBoundary):
     """Async boundary placed on a critic potential's per-unit log-weight change.
 
     Reacts to an expensive ``critic`` rather than the surface tokens or the cheap
@@ -595,12 +608,8 @@ class CriticBoundary(BoundaryPredicate):
         sign="abs",
         coalesce_grammar=False,
     ):
-        _validate_boundary_params(threshold, min_subunits, max_subunits, sign)
+        super().__init__(threshold, min_subunits, max_subunits, sign)
         self.critic = critic
-        self.threshold = threshold
-        self.min_subunits = min_subunits
-        self.max_subunits = max_subunits
-        self.sign = sign
         self.coalesce_grammar = coalesce_grammar
         # Per-unit baseline critic value, keyed by a hash of the completed context.
         # Cleared by reset(); grows with the number of distinct contexts seen.
@@ -625,7 +634,7 @@ class CriticBoundary(BoundaryPredicate):
         return self._baseline_cache[key]
 
     async def __call__(self, unit_context, subunit_buffer, **kwargs):
-        gate = _length_gate(len(subunit_buffer), self.min_subunits, self.max_subunits)
+        gate = self._gate(len(subunit_buffer))
         if gate is not None:
             return gate
 
@@ -643,7 +652,7 @@ class CriticBoundary(BoundaryPredicate):
             if isinstance(cw, (int, float)) and cw == cw:  # ignore NaN/non-numeric
                 delta += cw
 
-        return _crosses_threshold(delta, self.threshold, self.sign)
+        return self._crosses(delta)
 
     def __repr__(self):
         return (

--- a/tests/sampler/test_unit_sampler.py
+++ b/tests/sampler/test_unit_sampler.py
@@ -8,8 +8,13 @@ from genlm.control.sampler import (
     TokenSetBoundary,
     FixedLengthBoundary,
     BoundaryPredicate,
+    SurpriseBoundary,
+    CriticBoundary,
 )
-from genlm.control.sampler.unit import flatten_units
+from genlm.control.sampler.unit import (
+    flatten_units,
+    _predicate_accepts_cumulative_logw,
+)
 from genlm.control.sampler import CFGBoundary
 from genlm.control.sampler.sequence import SMC
 from genlm.control.constant import EOS
@@ -771,3 +776,255 @@ async def test_weight_is_negative_infinity_on_max_subunits():
     Z = 0.4 + 0.4 + 0.2
     expected_logp = 3 * np.log(0.4 / Z)
     assert np.isclose(logp, expected_logp, atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# cumulative_logw forwarding, async predicates, and backward compatibility
+# ---------------------------------------------------------------------------
+
+
+class RecordingBoundary(BoundaryPredicate):
+    """Records the cumulative_logw seen at each call; fires at a fixed length."""
+
+    def __init__(self, fire_at):
+        self.fire_at = fire_at
+        self.seen = []
+
+    def __call__(self, unit_context, subunit_buffer, **kwargs):
+        self.seen.append(kwargs.get("cumulative_logw"))
+        return len(subunit_buffer) >= self.fire_at
+
+
+@pytest.mark.asyncio
+async def test_cumulative_logw_passed_to_predicate():
+    """The predicate observes the running unit log-weight at every subunit."""
+    vocab = [b"a", b" "]
+    logws = np.log([3.0, 5.0, 2.0])  # Z != 1 -> per-token weight = log(Z)
+    Z = 10.0
+    subunit_sampler = DirectTokenSampler(MockPotential(vocab, logws))
+    boundary = RecordingBoundary(fire_at=3)
+    unit_sampler = MultiTokenUnitSampler(
+        subunit_sampler=subunit_sampler, boundary_predicate=boundary
+    )
+
+    unit, logw, _ = await unit_sampler.sample([], draw=lambda probs: b"a")
+    assert len(unit) == 3
+    # Predicate is called after each subunit is folded in: 1, 2, 3 multiples of log(Z).
+    expected = [np.log(Z), 2 * np.log(Z), 3 * np.log(Z)]
+    assert np.allclose(boundary.seen, expected, atol=1e-10)
+    assert np.isclose(logw, expected[-1], atol=1e-10)
+
+
+@pytest.mark.asyncio
+async def test_async_boundary_predicate_is_awaited():
+    """An async __call__ returning a coroutine is awaited by the sampler."""
+
+    class AsyncBoundary(BoundaryPredicate):
+        async def __call__(self, unit_context, subunit_buffer, **kwargs):
+            return abs(kwargs.get("cumulative_logw", 0.0)) >= 0.1
+
+    subunit_sampler = DirectTokenSampler(MockPotential([b"a"], np.log([3.0, 1.0])))
+    unit_sampler = MultiTokenUnitSampler(
+        subunit_sampler=subunit_sampler, boundary_predicate=AsyncBoundary()
+    )
+    unit, logw, _ = await unit_sampler.sample([], draw=lambda probs: b"a")
+    # A single token already crosses the threshold (log(4) > 0.1).
+    assert len(unit) == 1
+    assert np.isclose(logw, np.log(4.0), atol=1e-10)
+
+
+@pytest.mark.asyncio
+async def test_legacy_two_arg_predicate_still_works():
+    """A predicate with the legacy 2-arg signature is called without kwargs."""
+
+    class LegacyBoundary(BoundaryPredicate):
+        def __call__(self, unit_context, subunit_buffer):  # no **kwargs
+            return len(subunit_buffer) >= 2
+
+    subunit_sampler = DirectTokenSampler(MockPotential([b"a"], np.log([0.8, 0.2])))
+    unit_sampler = MultiTokenUnitSampler(
+        subunit_sampler=subunit_sampler, boundary_predicate=LegacyBoundary()
+    )
+    assert unit_sampler._boundary_accepts_cumulative_logw is False
+    unit, _, _ = await unit_sampler.sample([], draw=lambda probs: b"a")
+    assert len(unit) == 2
+
+
+def test_predicate_accepts_cumulative_logw_introspection():
+    """The signature probe accepts **kwargs and named params, rejects legacy."""
+
+    class Kwargs(BoundaryPredicate):
+        def __call__(self, unit_context, subunit_buffer, **kwargs):
+            return False
+
+    class Named(BoundaryPredicate):
+        def __call__(self, unit_context, subunit_buffer, cumulative_logw=0.0):
+            return False
+
+    class Legacy(BoundaryPredicate):
+        def __call__(self, unit_context, subunit_buffer):
+            return False
+
+    assert _predicate_accepts_cumulative_logw(Kwargs()) is True
+    assert _predicate_accepts_cumulative_logw(Named()) is True
+    assert _predicate_accepts_cumulative_logw(Legacy()) is False
+
+
+# ---------------------------------------------------------------------------
+# SurpriseBoundary
+# ---------------------------------------------------------------------------
+
+
+def test_surprise_boundary_validation():
+    with pytest.raises(ValueError, match="sign must be"):
+        SurpriseBoundary(sign="sideways")
+    with pytest.raises(ValueError, match="threshold must be positive"):
+        SurpriseBoundary(threshold=0)
+    with pytest.raises(ValueError, match="min_subunits must be >= 1"):
+        SurpriseBoundary(min_subunits=0)
+    with pytest.raises(ValueError, match="max_subunits .* must be >= min_subunits"):
+        SurpriseBoundary(min_subunits=5, max_subunits=3)
+
+
+def test_surprise_boundary_sign_variants_and_guards():
+    buf = [b"a", b"b"]
+    abs_b = SurpriseBoundary(threshold=1.0, sign="abs", min_subunits=2)
+    down_b = SurpriseBoundary(threshold=1.0, sign="down", min_subunits=2)
+    up_b = SurpriseBoundary(threshold=1.0, sign="up", min_subunits=2)
+
+    assert abs_b([], buf, cumulative_logw=-1.5) is True
+    assert abs_b([], buf, cumulative_logw=1.5) is True
+    assert abs_b([], buf, cumulative_logw=-0.5) is False
+    assert down_b([], buf, cumulative_logw=-1.5) is True
+    assert down_b([], buf, cumulative_logw=1.5) is False
+    assert up_b([], buf, cumulative_logw=1.5) is True
+    # NaN and non-numeric never fire.
+    assert abs_b([], buf, cumulative_logw=float("nan")) is False
+    assert abs_b([], buf, cumulative_logw=None) is False
+    assert "SurpriseBoundary" in repr(abs_b)
+
+
+def test_surprise_boundary_length_bounds():
+    boundary = SurpriseBoundary(threshold=1.0, min_subunits=3, max_subunits=4)
+    # Below min: never fires even past threshold.
+    assert boundary([], [b"a", b"b"], cumulative_logw=-9.0) is False
+    # Past max: force a fire even at zero surprise.
+    assert boundary([], [b"a"] * 4, cumulative_logw=0.0) is True
+
+
+# ---------------------------------------------------------------------------
+# CriticBoundary
+# ---------------------------------------------------------------------------
+
+
+class MockCritic:
+    """Minimal critic: prefix(context) = sum of per-token scores. Counts calls."""
+
+    def __init__(self, scores):
+        self.scores = scores
+        self.calls = 0
+
+    async def prefix(self, context):
+        self.calls += 1
+        return sum(self.scores.get(t, 0.0) for t in context)
+
+
+@pytest.mark.asyncio
+async def test_critic_boundary_fires_on_per_unit_delta():
+    """Fires on the critic delta over the in-progress unit, excluding completed ctx."""
+    boundary = CriticBoundary(MockCritic({b"a": -1.0}), threshold=1.5, min_subunits=1)
+    assert await boundary([], [b"a"]) is False  # delta -1.0, below 1.5
+    assert await boundary([], [b"a", b"a"]) is True  # delta -2.0
+    # Baseline subtracts the completed context, so delta reflects only the buffer.
+    assert await boundary([[b"a"], [b"a"]], [b"a"]) is False
+    assert await boundary([[b"a"], [b"a"]], [b"a", b"a"]) is True
+
+
+@pytest.mark.asyncio
+async def test_critic_boundary_sign_and_dead_particle():
+    buf = [b"a", b"a"]  # |delta| = 2.0
+    down = CriticBoundary(
+        MockCritic({b"a": -1.0}), threshold=1.5, sign="down", min_subunits=2
+    )
+    up = CriticBoundary(
+        MockCritic({b"a": 1.0}), threshold=1.5, sign="up", min_subunits=2
+    )
+    assert await down([], buf) is True
+    assert await up([], buf) is True
+    assert await up([], [b"x", b"x"]) is False  # zero delta, wrong direction
+
+    class DeadCritic:
+        async def prefix(self, context):
+            return float("-inf") if context else 0.0
+
+    dead = CriticBoundary(DeadCritic(), threshold=1.5, min_subunits=1, sign="abs")
+    assert await dead([], [b"a"]) is True  # -inf delta fires
+
+
+@pytest.mark.asyncio
+async def test_critic_boundary_coalesce_grammar():
+    critic = MockCritic({b"a": -0.5})  # critic delta alone (-1.0) below threshold
+    coalesce = CriticBoundary(
+        critic, threshold=1.5, min_subunits=1, coalesce_grammar=True
+    )
+    assert await coalesce([], [b"a", b"a"], cumulative_logw=0.0) is False
+    assert await coalesce([], [b"a", b"a"], cumulative_logw=-1.0) is True  # total -2.0
+    # Without coalescing, cumulative_logw is ignored.
+    plain = CriticBoundary(critic, threshold=1.5, min_subunits=1)
+    assert await plain([], [b"a", b"a"], cumulative_logw=-1.0) is False
+
+
+@pytest.mark.asyncio
+async def test_critic_boundary_length_bounds_skip_critic():
+    # Below min: no fire despite huge delta.
+    boundary = CriticBoundary(MockCritic({b"a": -10.0}), threshold=1.0, min_subunits=3)
+    assert await boundary([], [b"a", b"a"]) is False
+    # Past max: fires without calling the critic at all.
+    quiet = MockCritic({})
+    forced = CriticBoundary(quiet, threshold=100.0, min_subunits=1, max_subunits=3)
+    assert await forced([], [b"a", b"a", b"a"]) is True
+    assert quiet.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_critic_boundary_exception_does_not_fire():
+    class BoomCritic:
+        async def prefix(self, context):
+            raise RuntimeError("critic failure")
+
+    boundary = CriticBoundary(BoomCritic(), threshold=1.0, min_subunits=1)
+    assert await boundary([], [b"a"]) is False
+
+
+@pytest.mark.asyncio
+async def test_critic_boundary_baseline_cached_and_reset():
+    """Baseline is computed once per unit-context; reset() clears the cache."""
+    critic = MockCritic({b"a": -1.0})
+    boundary = CriticBoundary(critic, threshold=10.0, min_subunits=1)
+    await boundary([[b"a"]], [b"a"])
+    calls = critic.calls
+    await boundary([[b"a"]], [b"a", b"a"])
+    assert critic.calls == calls + 1  # only the current ctx is re-evaluated
+    boundary.reset()
+    assert boundary._baseline_cache == {}
+
+
+@pytest.mark.asyncio
+async def test_critic_boundary_integration_with_sampler():
+    """CriticBoundary (async) terminates a unit inside the sampler."""
+    subunit_sampler = DirectTokenSampler(
+        MockPotential([b"a", b"b"], np.log([0.4, 0.4, 0.2]))
+    )
+    boundary = CriticBoundary(MockCritic({b"a": -1.0}), threshold=1.5, min_subunits=1)
+    unit_sampler = MultiTokenUnitSampler(
+        subunit_sampler=subunit_sampler, boundary_predicate=boundary
+    )
+    assert unit_sampler._boundary_accepts_cumulative_logw is True
+    unit, _, _ = await unit_sampler.sample([], draw=lambda probs: b"a")
+    assert len(unit) == 2  # delta after 2 tokens = -2.0 crosses 1.5
+
+
+def test_new_boundaries_importable_from_package():
+    from genlm.control.sampler import SurpriseBoundary as S, CriticBoundary as C
+
+    assert S is SurpriseBoundary and C is CriticBoundary

--- a/tests/sampler/test_unit_sampler.py
+++ b/tests/sampler/test_unit_sampler.py
@@ -11,10 +11,7 @@ from genlm.control.sampler import (
     SurpriseBoundary,
     CriticBoundary,
 )
-from genlm.control.sampler.unit import (
-    flatten_units,
-    _predicate_accepts_cumulative_logw,
-)
+from genlm.control.sampler.unit import flatten_units
 from genlm.control.sampler import CFGBoundary
 from genlm.control.sampler.sequence import SMC
 from genlm.control.constant import EOS
@@ -865,9 +862,10 @@ def test_predicate_accepts_cumulative_logw_introspection():
         def __call__(self, unit_context, subunit_buffer):
             return False
 
-    assert _predicate_accepts_cumulative_logw(Kwargs()) is True
-    assert _predicate_accepts_cumulative_logw(Named()) is True
-    assert _predicate_accepts_cumulative_logw(Legacy()) is False
+    probe = MultiTokenUnitSampler._predicate_accepts_cumulative_logw
+    assert probe(Kwargs()) is True
+    assert probe(Named()) is True
+    assert probe(Legacy()) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- Extend `MultiTokenUnitSampler` to add support and templates for `SurpriseBoundary` and `CriticBoundary` boundaries.
- Add documentation.