### PR TITLE
Fix AWRS ZeroDivisionError

### DIFF
--- a/genlm/control/sampler/token.py
+++ b/genlm/control/sampler/token.py
@@ -749,7 +749,10 @@ async def geometric_awrs(*, logps, toks, accept, make_keys, rng, max_rejects, ma
     # 1 if the first sample was accepted and 0 if it was rejected
     # to the sufficient statistic (n_accepts, n_rejects). Some
     # straightforward sequence counting gives you this estimator.
-    estimator = min(max_accepts - 1, n_accepts) / (n_accepts + n_rejects - 1)
+    # denom == 0 means a single accepted draw with no rejects (peaked target,
+    # accepted immediately); the acceptance-prob estimate is 1 -- avoid 0/0.
+    denom = n_accepts + n_rejects - 1
+    estimator = min(max_accepts - 1, n_accepts) / denom if denom > 0 else 1.0
 
     assert estimator > 0 or result is None
 

--- a/tests/sampler/test_awrs.py
+++ b/tests/sampler/test_awrs.py
@@ -1012,3 +1012,21 @@ async def test_geometric_awrs_validity(logps, accept, rng, max_rejects, max_acce
         assert logp > -np.inf
     else:
         assert logp == -np.inf
+
+
+@pytest.mark.asyncio
+async def test_geometric_awrs_max_accepts_one_no_zerodiv():
+    """Regression: max_accepts=1 gives a single accepted draw (n_accepts+n_rejects==1),
+    so the estimator denominator is 0. Must not ZeroDivisionError; weight is finite."""
+    logps = np.array([0.0, -10.0])  # peaked on token 0
+    tok, logp, _ = await geometric_awrs(
+        logps=torch.as_tensor(logps),
+        toks=np.arange(len(logps)),
+        accept=always_accept,
+        make_keys=_keys_from(np.random.default_rng(0)),
+        rng=np.random.default_rng(0),
+        max_rejects=2,
+        max_accepts=1,
+    )
+    assert tok == 0
+    assert logp == 0.0  # estimator == 1


### PR DESCRIPTION
`geometric_awrs` computes `estimator = min(max_accepts-1, n_accepts) / (n_accepts + n_rejects - 1)`
When a draw is accepted with no rejects the denominator is 0 and AWRS raises ZeroDivisionError -> crashed every AWRS on goal inference, molecular synthesis, spider

Fix: when denom == 0 the acceptance-probability estimate is 1 (log-weight 0).

Test: adds `test_geometric_awrs_max_accepts_one_no_zerodiv` (max_accepts=1).